### PR TITLE
allow limits on sequences

### DIFF
--- a/parsers/manifest_parser.go
+++ b/parsers/manifest_parser.go
@@ -503,6 +503,13 @@ func (dm *YAMLParser) ComposeSequences(namespace string, sequences map[string]Se
 			wskaction.Annotations = annotations
 		}
 
+		// Limits
+		if sequence.Limits != nil {
+			if wsklimits := dm.composeActionLimits(*(sequence.Limits)); wsklimits != nil {
+				wskaction.Limits = wsklimits
+			}
+		}
+
 		// appending managed annotations if its a managed deployment
 		if utils.Flags.Managed || utils.Flags.Sync {
 			wskaction.Annotations = append(wskaction.Annotations, managedAnnotations)

--- a/parsers/manifest_parser_test.go
+++ b/parsers/manifest_parser_test.go
@@ -1499,9 +1499,9 @@ func TestComposeSequences(t *testing.T) {
 		switch wsk_action.Name {
 		case "sequence1":
 			assert.Equal(t, "sequence", wsk_action.Exec.Kind, "Failed to set sequence exec kind")
-			assert.Equal(t, 1024, wsk_action.Limits.Memory, "Failed to get Memory")
-			assert.Equal(t, 180, wsk_action.Limits.Timeout, "Failed to get Timeout")
-			assert.Equal(t, 1, wsk_action.Limits.Logsize, "Failed to get Logsize")
+			assert.Equal(t, 1024, strconv.FormatInt(int64(wsk_action.Limits.Memory.(int)), "Failed to get Memory")
+			assert.Equal(t, 180, strconv.FormatInt(int64(wsk_action.Limits.Timeout.(int)), "Failed to get Timeout")
+			assert.Equal(t, 1, strconv.FormatInt(int64(wsk_action.Limits.Logsize.(int)), "Failed to get Logsize")
 			assert.Equal(t, 2, len(wsk_action.Exec.Components), "Failed to set sequence exec components")
 			assert.Equal(t, "/helloworld/action1", wsk_action.Exec.Components[0], "Failed to set sequence 1st exec components")
 			assert.Equal(t, "/helloworld/action2", wsk_action.Exec.Components[1], "Failed to set sequence 2nd exec components")

--- a/parsers/manifest_parser_test.go
+++ b/parsers/manifest_parser_test.go
@@ -1499,9 +1499,9 @@ func TestComposeSequences(t *testing.T) {
 		switch wsk_action.Name {
 		case "sequence1":
 			assert.Equal(t, "sequence", wsk_action.Exec.Kind, "Failed to set sequence exec kind")
-			assert.Equal(t, 1024, strconv.FormatInt(int64(wsk_action.Limits.Memory.(int)), "Failed to get Memory")
-			assert.Equal(t, 180, strconv.FormatInt(int64(wsk_action.Limits.Timeout.(int)), "Failed to get Timeout")
-			assert.Equal(t, 1, strconv.FormatInt(int64(wsk_action.Limits.Logsize.(int)), "Failed to get Logsize")
+			assert.Equal(t, 1024, strconv.FormatInt(int64(wsk_action.Limits.Memory.(int))), "Failed to get Memory")
+			assert.Equal(t, 180, strconv.FormatInt(int64(wsk_action.Limits.Timeout.(int))), "Failed to get Timeout")
+			assert.Equal(t, 1, strconv.FormatInt(int64(wsk_action.Limits.Logsize.(int))), "Failed to get Logsize")
 			assert.Equal(t, 2, len(wsk_action.Exec.Components), "Failed to set sequence exec components")
 			assert.Equal(t, "/helloworld/action1", wsk_action.Exec.Components[0], "Failed to set sequence 1st exec components")
 			assert.Equal(t, "/helloworld/action2", wsk_action.Exec.Components[1], "Failed to set sequence 2nd exec components")

--- a/parsers/manifest_parser_test.go
+++ b/parsers/manifest_parser_test.go
@@ -1499,6 +1499,9 @@ func TestComposeSequences(t *testing.T) {
 		switch wsk_action.Name {
 		case "sequence1":
 			assert.Equal(t, "sequence", wsk_action.Exec.Kind, "Failed to set sequence exec kind")
+			assert.Equal(t, 1024, wsk_action.Limits.Memory, "Failed to get Memory")
+			assert.Equal(t, 180, wsk_action.Limits.Timeout, "Failed to get Timeout")
+			assert.Equal(t, 1, wsk_action.Limits.Logsize, "Failed to get Logsize")
 			assert.Equal(t, 2, len(wsk_action.Exec.Components), "Failed to set sequence exec components")
 			assert.Equal(t, "/helloworld/action1", wsk_action.Exec.Components[0], "Failed to set sequence 1st exec components")
 			assert.Equal(t, "/helloworld/action2", wsk_action.Exec.Components[1], "Failed to set sequence 2nd exec components")

--- a/parsers/yamlparser.go
+++ b/parsers/yamlparser.go
@@ -132,6 +132,7 @@ type Sequence struct {
 	Actions     string                 `yaml:"actions"`
 	Web         string                 `yaml:"web"`
 	Annotations map[string]interface{} `yaml:"annotations,omitempty"`
+	Limits      *Limits                `yaml:"limits"`
 }
 
 type Dependency struct {

--- a/tests/dat/manifest_data_compose_sequences.yaml
+++ b/tests/dat/manifest_data_compose_sequences.yaml
@@ -6,5 +6,9 @@ packages:
     sequences:
       sequence1:
         actions: action1, action2
+        limits:
+          memorySize: 1024
+          timeout: 180
+          logSize: 1
       sequence2:
         actions: action3, action4, action5


### PR DESCRIPTION
Limits (like memorySize and timeout) should be allowed on sequences, since they can be set via the wsk cli
see #1042 