### PR TITLE
Support Description field in corresponding entities

### DIFF
--- a/parsers/yamlparser.go
+++ b/parsers/yamlparser.go
@@ -113,6 +113,7 @@ type Action struct {
 	Limits      *Limits                `yaml:"limits"`
 	Inputs      map[string]Parameter   `yaml:"inputs"`
 	Outputs     map[string]Parameter   `yaml:"outputs"`
+	Description string                 `yaml:"description,omitempty"`
 	Annotations map[string]interface{} `yaml:"annotations,omitempty"`
 	Include     [][]string             `yaml:"include,omitempty"`
 	Exclude     []string               `yaml:"exclude,omitempty"`
@@ -159,6 +160,7 @@ type Trigger struct {
 	Credential  string               `yaml:"credential"`
 	Inputs      map[string]Parameter `yaml:"inputs"`
 	Name        string
+	Description string                 `yaml:"description,omitempty"`
 	Annotations map[string]interface{} `yaml:"annotations,omitempty"`
 	// TODO() this is propoagated from package to trigger within that package
 	//Parameters  map[string]interface{} `yaml:parameters`
@@ -185,6 +187,7 @@ type Rule struct {
 	Rule   string `yaml:"rule"`   //used in manifest.yaml
 	//mapping to wsk.Rule.Name
 	Name        string
+	Description string                 `yaml:"description,omitempty"`
 	Annotations map[string]interface{} `yaml:"annotations,omitempty"`
 }
 
@@ -216,6 +219,7 @@ type Package struct {
 	Rules            map[string]Rule                                               `yaml:"rules"`
 	Inputs           map[string]Parameter                                          `yaml:"inputs"`
 	Sequences        map[string]Sequence                                           `yaml:"sequences"`
+	Description      string                                                        `yaml:"description,omitempty"`
 	Annotations      map[string]interface{}                                        `yaml:"annotations,omitempty"`
 	Apis             map[string]map[string]map[string]map[string]APIMethodResponse `yaml:"apis"`
 }

--- a/tests/dat/manifest_validate_package_grammar.yaml
+++ b/tests/dat/manifest_validate_package_grammar.yaml
@@ -20,3 +20,4 @@ packages:
   helloworld:
     version: 1.0
     license: Apache-2.0
+    description: Foo Bar

--- a/tests/dat/manifest_validate_package_grammar_env_var.yaml
+++ b/tests/dat/manifest_validate_package_grammar_env_var.yaml
@@ -20,6 +20,7 @@ packages:
   $package_name:
     version: 1.0
     license: Apache-2.0
+    description: Foo Bar
   $package_name_second:
     version: 1.0
     license: Apache-2.0

--- a/tests/dat/manifest_validate_trigger_action_rule_grammar.yaml
+++ b/tests/dat/manifest_validate_trigger_action_rule_grammar.yaml
@@ -22,8 +22,10 @@ packages:
         license: Apache-2.0
         actions:
             first_action:
+                description: Foo Bar 1
                 function: actions/dump_params.js
             second_action:
+                description: Foo Bar 2
                 function: actions/dump_params.js
             third_action:
                 function: actions/dump_params.js
@@ -32,9 +34,11 @@ packages:
             trigger2:
         rules:
             rule1:
+                description: Foo Bar 1
                 trigger: trigger1
                 action: first_action
             rule3:
+                description: Foo Bar 2
                 trigger: trigger2
                 action: second_action
             rule2:


### PR DESCRIPTION
The Description field should be supported across all entities, as it is
included in the "Shared Entity Schema".

Fixes: #548