### PR TITLE
added rust 1.34 support

### DIFF
--- a/runtimes/runtimes.go
+++ b/runtimes/runtimes.go
@@ -564,7 +564,7 @@ var RUNTIME_DETAILS = []byte(`{
                     "tag": "latest"
                 }
             }
-        ], 
+        ],
         "dotnet": [
             {
                 "kind": "dotnet:2.2",

--- a/runtimes/runtimes.go
+++ b/runtimes/runtimes.go
@@ -549,6 +549,22 @@ var RUNTIME_DETAILS = []byte(`{
                 }
             }
         ],
+        "rust": [
+            {
+                "kind": "rust:1.34",
+                "default": true,
+                "deprecated": false,
+                "attached": {
+                    "attachmentName": "codefile",
+                    "attachmentType": "text/plain"
+                },
+                "image": {
+                    "prefix": "openwhisk",
+                    "name": "actionloop-rust-v1.34",
+                    "tag": "latest"
+                }
+            }
+        ], 
         "dotnet": [
             {
                 "kind": "dotnet:2.2",

--- a/specification/html/spec_actions.md
+++ b/specification/html/spec_actions.md
@@ -147,6 +147,7 @@ These packages may vary by OpenWhisk release; examples of supported runtimes as 
 | swift@4.2 | swift:4.2 | openwhisk/action-swift-v4.2:latest | Latest Swift 4.2 language runtime |
 | swift@4.1 | swift:4.1 | openwhisk/action-swift-v4.1:latest | Latest Swift 4.1 language runtime |
 | swift@3.1.1 | swift:3.1.1 | openwhisk/action-swift-v3.1.1:latest | Latest Swift 3.1.1 language runtime |
+| rust@1.34 | rust:1.34 | openwhisk/actionloop-rust-v1.34:latest | Latest Rust 1.34 language runtime |
 | dotnet, dotnet@2.2 | dotnet:2.2 | openwhisk/action-dotnet-v2.2:latest | Latest .NET Core 2.2 runtime |
 | language:default | N/A | N/A | Permit the OpenWhisk platform to select the correct default language runtime. |
 
@@ -194,6 +195,11 @@ following file extensions are recognized and will be run on the latest version o
   <td>.rb</td>
   <td>ruby</td>
   <td>Latest Ruby language runtime.</td>
+ </tr>
+ <tr>
+  <td>.rs</td>
+  <td>rust</td>
+  <td>Latest Rust language runtime.</td>
  </tr>
 </table>
 </html>

--- a/tests/src/integration/runtimetests/manifest.yaml
+++ b/tests/src/integration/runtimetests/manifest.yaml
@@ -130,6 +130,16 @@ packages:
                     place: string
                 outputs:
                     payload: string
+            greetingrust134-with-explicit-runtime:
+                web-export: true
+                version: 1.0
+                function: src/lib.rs
+                runtime: rust:1.3.4
+                inputs:
+                    name: string
+                    place: string
+                outputs:
+                    payload: string
             helloworldjava-with-explicit-runtime:
                 function: src/hello.jar
                 runtime: java
@@ -188,6 +198,15 @@ packages:
                 web-export: true
                 version: 1.0
                 function: src/hello.swift
+                inputs:
+                    name: string
+                    place: string
+                outputs:
+                    payload: string
+            greetingsrust134-without-explicit-runtime:
+                web-export: true
+                version: 1.0
+                function: src/lib.rs
                 inputs:
                     name: string
                     place: string
@@ -289,6 +308,26 @@ packages:
                 outputs:
                     payload: string
             greetingswift-with-random-explicit-runtime:
+                web-export: true
+                version: 1.0
+                function: src/hello.swift
+                runtime: random
+                inputs:
+                    name: string
+                    place: string
+                outputs:
+                    payload: string
+            greetingsrust134-with-nodejs-explicit-runtime:
+                web-export: true
+                version: 1.0
+                function: src/hello.rs
+                runtime: nodejs:6
+                inputs:
+                    name: string
+                    place: string
+                outputs:
+                    payload: string
+            greetingsrust134-with-random-explicit-runtime:
                 web-export: true
                 version: 1.0
                 function: src/hello.swift

--- a/tests/src/integration/runtimetests/src/lib.rs
+++ b/tests/src/integration/runtimetests/src/lib.rs
@@ -1,0 +1,27 @@
+extern crate serde_json;
+
+use serde_derive::{Deserialize, Serialize};
+use serde_json::{Error, Value};
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+struct Input {
+    #[serde(default = "stranger")]
+    name: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+struct Output {
+    greeting: String,
+}
+
+fn stranger() -> String {
+    "stranger".to_string()
+}
+
+pub fn main(args: Value) -> Result<Value, Error> {
+    let input: Input = serde_json::from_value(args)?;
+    let output = Output {
+        greeting: format!("Hello, {}", input.name),
+    };
+    serde_json::to_value(output)
+}


### PR DESCRIPTION
In order to fully integrate Rust support to Openwhisk in this PR we are adding all the necessary tests to support Rust 1.34. This PR is part of the work proposed in this issue: apache/openwhisk#4443