### PR TITLE
Add the ability to specify api via swagger in manifest

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -1,8 +1,16 @@
 {
 	"ImportPath": "github.com/apache/openwhisk-wskdeploy",
 	"GoVersion": "go1.9",
-	"GodepVersion": "v62",
+	"GodepVersion": "v80",
 	"Deps": [
+		{
+			"ImportPath": "github.com/apache/openwhisk-client-go/whisk",
+			"Rev": "ee5b8709787cd37201c42e38040e9709f6d1e9c8"
+		},
+		{
+			"ImportPath": "github.com/apache/openwhisk-client-go/wski18n",
+			"Rev": "ee5b8709787cd37201c42e38040e9709f6d1e9c8"
+		},
 		{
 			"ImportPath": "github.com/cloudfoundry/jibber_jabber",
 			"Rev": "bcc4c8345a21301bf47c032ff42dd1aae2fe3027"
@@ -13,49 +21,13 @@
 			"Rev": "570b54cabe6b8eb0bc2dfce68d964677d63b5260"
 		},
 		{
-			"ImportPath": "github.com/fsnotify/fsnotify",
-			"Comment": "v1.4.2-2-gfd9ec7d",
-			"Rev": "fd9ec7deca8bf46ecd2a795baaacf2b3a9be1197"
+			"ImportPath": "github.com/ghodss/yaml",
+			"Comment": "v1.0.0-14-g25d852a",
+			"Rev": "25d852aebe32c875e9c044af3eef9c7dc6bc777f"
 		},
 		{
 			"ImportPath": "github.com/google/go-querystring/query",
 			"Rev": "9235644dd9e52eeae6fa48efd539fdc351a0af53"
-		},
-		{
-			"ImportPath": "github.com/hashicorp/hcl",
-			"Rev": "973f376f0e7cf09c96e445b44712416c0cb22ec4"
-		},
-		{
-			"ImportPath": "github.com/hashicorp/hcl/hcl/ast",
-			"Rev": "973f376f0e7cf09c96e445b44712416c0cb22ec4"
-		},
-		{
-			"ImportPath": "github.com/hashicorp/hcl/hcl/parser",
-			"Rev": "973f376f0e7cf09c96e445b44712416c0cb22ec4"
-		},
-		{
-			"ImportPath": "github.com/hashicorp/hcl/hcl/scanner",
-			"Rev": "973f376f0e7cf09c96e445b44712416c0cb22ec4"
-		},
-		{
-			"ImportPath": "github.com/hashicorp/hcl/hcl/strconv",
-			"Rev": "973f376f0e7cf09c96e445b44712416c0cb22ec4"
-		},
-		{
-			"ImportPath": "github.com/hashicorp/hcl/hcl/token",
-			"Rev": "973f376f0e7cf09c96e445b44712416c0cb22ec4"
-		},
-		{
-			"ImportPath": "github.com/hashicorp/hcl/json/parser",
-			"Rev": "973f376f0e7cf09c96e445b44712416c0cb22ec4"
-		},
-		{
-			"ImportPath": "github.com/hashicorp/hcl/json/scanner",
-			"Rev": "973f376f0e7cf09c96e445b44712416c0cb22ec4"
-		},
-		{
-			"ImportPath": "github.com/hashicorp/hcl/json/token",
-			"Rev": "973f376f0e7cf09c96e445b44712416c0cb22ec4"
 		},
 		{
 			"ImportPath": "github.com/hokaccha/go-prettyjson",
@@ -66,11 +38,6 @@
 			"Rev": "76626ae9c91c4f2a10f34cad8ce83ea42c93bb75"
 		},
 		{
-			"ImportPath": "github.com/magiconair/properties",
-			"Comment": "v1.7.0-5-g0723e35",
-			"Rev": "0723e352fa358f9322c938cc2dadda874e9151a9"
-		},
-		{
 			"ImportPath": "github.com/mattn/go-colorable",
 			"Comment": "v0.0.6-9-gd228849",
 			"Rev": "d228849504861217f796da67fae4f6e347643f15"
@@ -78,10 +45,6 @@
 		{
 			"ImportPath": "github.com/mattn/go-isatty",
 			"Rev": "66b8e73f3f5cda9f96b69efd03dd3d7fc4a5cdb8"
-		},
-		{
-			"ImportPath": "github.com/mitchellh/mapstructure",
-			"Rev": "f3009df150dadf309fdee4a54ed65c124afad715"
 		},
 		{
 			"ImportPath": "github.com/nicksnyder/go-i18n/i18n",
@@ -104,69 +67,20 @@
 			"Rev": "991e81cc94f6c54209edb3192cb98e3995ad71c1"
 		},
 		{
-			"ImportPath": "github.com/apache/openwhisk-client-go/whisk",
-			"Rev": "ee5b8709787cd37201c42e38040e9709f6d1e9c8"
-		},
-		{
-			"ImportPath": "github.com/apache/openwhisk-client-go/wski18n",
-			"Rev": "ee5b8709787cd37201c42e38040e9709f6d1e9c8"
-		},
-		{
-			"ImportPath": "github.com/pelletier/go-buffruneio",
-			"Rev": "df1e16fde7fc330a0ca68167c23bf7ed6ac31d6d"
-		},
-		{
-			"ImportPath": "github.com/pelletier/go-toml",
-			"Comment": "v0.3.5-16-g45932ad",
-			"Rev": "45932ad32dfdd20826f5671da37a5f3ce9f26a8d"
-		},
-		{
-			"ImportPath": "github.com/spf13/afero",
-			"Rev": "06b7e5f50606ecd49148a01a6008942d9b669217"
-		},
-		{
-			"ImportPath": "github.com/spf13/afero/mem",
-			"Rev": "06b7e5f50606ecd49148a01a6008942d9b669217"
-		},
-		{
-			"ImportPath": "github.com/spf13/cast",
-			"Rev": "2580bc98dc0e62908119e4737030cc2fdfc45e4c"
-		},
-		{
 			"ImportPath": "github.com/spf13/cobra",
 			"Rev": "6e91dded25d73176bf7f60b40dd7aa1f0bf9be8d"
-		},
-		{
-			"ImportPath": "github.com/spf13/jwalterweatherman",
-			"Rev": "33c24e77fb80341fe7130ee7c594256ff08ccc46"
 		},
 		{
 			"ImportPath": "github.com/spf13/pflag",
 			"Rev": "5ccb023bc27df288a957c5e994cd44fd19619465"
 		},
 		{
-			"ImportPath": "github.com/spf13/viper",
-			"Rev": "651d9d916abc3c3d6a91a12549495caba5edffd2"
-		},
-		{
 			"ImportPath": "golang.org/x/sys/unix",
 			"Rev": "9a2e24c3733eddc63871eda99f253e2db29bd3b9"
 		},
 		{
-			"ImportPath": "golang.org/x/text/transform",
-			"Rev": "a8b38433e35b65ba247bb267317037dee1b70cea"
-		},
-		{
-			"ImportPath": "golang.org/x/text/unicode/norm",
-			"Rev": "a8b38433e35b65ba247bb267317037dee1b70cea"
-		},
-		{
 			"ImportPath": "gopkg.in/yaml.v2",
 			"Rev": "eb3733d160e74a9c7e442f435eb3bea458e1d19f"
-		},
-        {
-            "ImportPath": "github.com/palantir/stacktrace",
-            "Rev": "78658fd2d1772b755720ed8c44367d11ee5380d6"
-        }
+		}
 	]
 }

--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -164,9 +164,13 @@
 			"ImportPath": "gopkg.in/yaml.v2",
 			"Rev": "eb3733d160e74a9c7e442f435eb3bea458e1d19f"
 		},
-        {
-            "ImportPath": "github.com/palantir/stacktrace",
-            "Rev": "78658fd2d1772b755720ed8c44367d11ee5380d6"
-        }
+    {
+      "ImportPath": "github.com/palantir/stacktrace",
+      "Rev": "78658fd2d1772b755720ed8c44367d11ee5380d6"
+    },
+    {
+      "ImportPath": "github.com/ghodss/yaml",
+      "Rev": "25d852aebe32c875e9c044af3eef9c7dc6bc777f"
+    }
 	]
 }

--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -1,16 +1,8 @@
 {
 	"ImportPath": "github.com/apache/openwhisk-wskdeploy",
 	"GoVersion": "go1.9",
-	"GodepVersion": "v80",
+	"GodepVersion": "v62",
 	"Deps": [
-		{
-			"ImportPath": "github.com/apache/openwhisk-client-go/whisk",
-			"Rev": "ee5b8709787cd37201c42e38040e9709f6d1e9c8"
-		},
-		{
-			"ImportPath": "github.com/apache/openwhisk-client-go/wski18n",
-			"Rev": "ee5b8709787cd37201c42e38040e9709f6d1e9c8"
-		},
 		{
 			"ImportPath": "github.com/cloudfoundry/jibber_jabber",
 			"Rev": "bcc4c8345a21301bf47c032ff42dd1aae2fe3027"
@@ -21,13 +13,49 @@
 			"Rev": "570b54cabe6b8eb0bc2dfce68d964677d63b5260"
 		},
 		{
-			"ImportPath": "github.com/ghodss/yaml",
-			"Comment": "v1.0.0-14-g25d852a",
-			"Rev": "25d852aebe32c875e9c044af3eef9c7dc6bc777f"
+			"ImportPath": "github.com/fsnotify/fsnotify",
+			"Comment": "v1.4.2-2-gfd9ec7d",
+			"Rev": "fd9ec7deca8bf46ecd2a795baaacf2b3a9be1197"
 		},
 		{
 			"ImportPath": "github.com/google/go-querystring/query",
 			"Rev": "9235644dd9e52eeae6fa48efd539fdc351a0af53"
+		},
+		{
+			"ImportPath": "github.com/hashicorp/hcl",
+			"Rev": "973f376f0e7cf09c96e445b44712416c0cb22ec4"
+		},
+		{
+			"ImportPath": "github.com/hashicorp/hcl/hcl/ast",
+			"Rev": "973f376f0e7cf09c96e445b44712416c0cb22ec4"
+		},
+		{
+			"ImportPath": "github.com/hashicorp/hcl/hcl/parser",
+			"Rev": "973f376f0e7cf09c96e445b44712416c0cb22ec4"
+		},
+		{
+			"ImportPath": "github.com/hashicorp/hcl/hcl/scanner",
+			"Rev": "973f376f0e7cf09c96e445b44712416c0cb22ec4"
+		},
+		{
+			"ImportPath": "github.com/hashicorp/hcl/hcl/strconv",
+			"Rev": "973f376f0e7cf09c96e445b44712416c0cb22ec4"
+		},
+		{
+			"ImportPath": "github.com/hashicorp/hcl/hcl/token",
+			"Rev": "973f376f0e7cf09c96e445b44712416c0cb22ec4"
+		},
+		{
+			"ImportPath": "github.com/hashicorp/hcl/json/parser",
+			"Rev": "973f376f0e7cf09c96e445b44712416c0cb22ec4"
+		},
+		{
+			"ImportPath": "github.com/hashicorp/hcl/json/scanner",
+			"Rev": "973f376f0e7cf09c96e445b44712416c0cb22ec4"
+		},
+		{
+			"ImportPath": "github.com/hashicorp/hcl/json/token",
+			"Rev": "973f376f0e7cf09c96e445b44712416c0cb22ec4"
 		},
 		{
 			"ImportPath": "github.com/hokaccha/go-prettyjson",
@@ -38,6 +66,11 @@
 			"Rev": "76626ae9c91c4f2a10f34cad8ce83ea42c93bb75"
 		},
 		{
+			"ImportPath": "github.com/magiconair/properties",
+			"Comment": "v1.7.0-5-g0723e35",
+			"Rev": "0723e352fa358f9322c938cc2dadda874e9151a9"
+		},
+		{
 			"ImportPath": "github.com/mattn/go-colorable",
 			"Comment": "v0.0.6-9-gd228849",
 			"Rev": "d228849504861217f796da67fae4f6e347643f15"
@@ -45,6 +78,10 @@
 		{
 			"ImportPath": "github.com/mattn/go-isatty",
 			"Rev": "66b8e73f3f5cda9f96b69efd03dd3d7fc4a5cdb8"
+		},
+		{
+			"ImportPath": "github.com/mitchellh/mapstructure",
+			"Rev": "f3009df150dadf309fdee4a54ed65c124afad715"
 		},
 		{
 			"ImportPath": "github.com/nicksnyder/go-i18n/i18n",
@@ -67,20 +104,69 @@
 			"Rev": "991e81cc94f6c54209edb3192cb98e3995ad71c1"
 		},
 		{
+			"ImportPath": "github.com/apache/openwhisk-client-go/whisk",
+			"Rev": "ee5b8709787cd37201c42e38040e9709f6d1e9c8"
+		},
+		{
+			"ImportPath": "github.com/apache/openwhisk-client-go/wski18n",
+			"Rev": "ee5b8709787cd37201c42e38040e9709f6d1e9c8"
+		},
+		{
+			"ImportPath": "github.com/pelletier/go-buffruneio",
+			"Rev": "df1e16fde7fc330a0ca68167c23bf7ed6ac31d6d"
+		},
+		{
+			"ImportPath": "github.com/pelletier/go-toml",
+			"Comment": "v0.3.5-16-g45932ad",
+			"Rev": "45932ad32dfdd20826f5671da37a5f3ce9f26a8d"
+		},
+		{
+			"ImportPath": "github.com/spf13/afero",
+			"Rev": "06b7e5f50606ecd49148a01a6008942d9b669217"
+		},
+		{
+			"ImportPath": "github.com/spf13/afero/mem",
+			"Rev": "06b7e5f50606ecd49148a01a6008942d9b669217"
+		},
+		{
+			"ImportPath": "github.com/spf13/cast",
+			"Rev": "2580bc98dc0e62908119e4737030cc2fdfc45e4c"
+		},
+		{
 			"ImportPath": "github.com/spf13/cobra",
 			"Rev": "6e91dded25d73176bf7f60b40dd7aa1f0bf9be8d"
+		},
+		{
+			"ImportPath": "github.com/spf13/jwalterweatherman",
+			"Rev": "33c24e77fb80341fe7130ee7c594256ff08ccc46"
 		},
 		{
 			"ImportPath": "github.com/spf13/pflag",
 			"Rev": "5ccb023bc27df288a957c5e994cd44fd19619465"
 		},
 		{
+			"ImportPath": "github.com/spf13/viper",
+			"Rev": "651d9d916abc3c3d6a91a12549495caba5edffd2"
+		},
+		{
 			"ImportPath": "golang.org/x/sys/unix",
 			"Rev": "9a2e24c3733eddc63871eda99f253e2db29bd3b9"
 		},
 		{
+			"ImportPath": "golang.org/x/text/transform",
+			"Rev": "a8b38433e35b65ba247bb267317037dee1b70cea"
+		},
+		{
+			"ImportPath": "golang.org/x/text/unicode/norm",
+			"Rev": "a8b38433e35b65ba247bb267317037dee1b70cea"
+		},
+		{
 			"ImportPath": "gopkg.in/yaml.v2",
 			"Rev": "eb3733d160e74a9c7e442f435eb3bea458e1d19f"
-		}
+		},
+        {
+            "ImportPath": "github.com/palantir/stacktrace",
+            "Rev": "78658fd2d1772b755720ed8c44367d11ee5380d6"
+        }
 	]
 }

--- a/deployers/manifestreader.go
+++ b/deployers/manifestreader.go
@@ -113,6 +113,11 @@ func (reader *ManifestReader) HandleYaml(manifestParser *parsers.YAMLParser, man
 		return wskderrors.NewYAMLFileFormatError(manifestName, err)
 	}
 
+	api, response, err := manifestParser.ComposeApiRecordsFromSwagger(reader.serviceDeployer.ClientConfig, manifest)
+	if err != nil {
+		return wskderrors.NewYAMLFileFormatError(manifestName, err)
+	}
+
 	err = reader.SetDependencies(deps)
 	if err != nil {
 		return wskderrors.NewYAMLFileFormatError(manifestName, err)
@@ -139,6 +144,11 @@ func (reader *ManifestReader) HandleYaml(manifestParser *parsers.YAMLParser, man
 	}
 
 	err = reader.SetApis(apis, responses)
+	if err != nil {
+		return wskderrors.NewYAMLFileFormatError(manifestName, err)
+	}
+
+	err = reader.SetSwaggerApi(api, response)
 	if err != nil {
 		return wskderrors.NewYAMLFileFormatError(manifestName, err)
 	}
@@ -319,6 +329,16 @@ func (reader *ManifestReader) SetApis(ar []*whisk.ApiCreateRequest, responses ma
 		dep.Deployment.ApiOptions[apiPath] = response
 	}
 
+	return nil
+}
+
+func (reader *ManifestReader) SetSwaggerApi(api *whisk.ApiCreateRequest, response *whisk.ApiCreateRequestOptions) error {
+	dep := reader.serviceDeployer
+
+	dep.mt.Lock()
+	defer dep.mt.Unlock()
+	dep.Deployment.SwaggerApi = api
+	dep.Deployment.SwaggerApiOptions = response
 	return nil
 }
 

--- a/deployers/servicedeployer.go
+++ b/deployers/servicedeployer.go
@@ -811,10 +811,13 @@ func (deployer *ServiceDeployer) DeployRules() error {
 // Deploy Apis into OpenWhisk
 func (deployer *ServiceDeployer) DeployApis() error {
 	var err error
-	// Only deploy either swagger or manifest defined api, but not both
-	// Swagger API takes precedence
+	// NOTE: Only deploy either swagger or manifest defined api, but not both
+	// NOTE: Swagger API takes precedence
 	if deployer.Deployment.SwaggerApi != nil && deployer.Deployment.SwaggerApiOptions != nil {
 		err = deployer.createSwaggerApi(deployer.Deployment.SwaggerApi)
+		if err != nil {
+			return err
+		}
 	} else {
 		for _, api := range deployer.Deployment.Apis {
 			err = deployer.createApi(api)

--- a/deployers/servicedeployer.go
+++ b/deployers/servicedeployer.go
@@ -45,11 +45,13 @@ const (
 )
 
 type DeploymentProject struct {
-	Packages   map[string]*DeploymentPackage
-	Triggers   map[string]*whisk.Trigger
-	Rules      map[string]*whisk.Rule
-	Apis       map[string]*whisk.ApiCreateRequest
-	ApiOptions map[string]*whisk.ApiCreateRequestOptions
+	Packages          map[string]*DeploymentPackage
+	Triggers          map[string]*whisk.Trigger
+	Rules             map[string]*whisk.Rule
+	Apis              map[string]*whisk.ApiCreateRequest
+	ApiOptions        map[string]*whisk.ApiCreateRequestOptions
+	SwaggerApi        *whisk.ApiCreateRequest
+	SwaggerApiOptions *whisk.ApiCreateRequestOptions
 }
 
 func NewDeploymentProject() *DeploymentProject {
@@ -808,10 +810,17 @@ func (deployer *ServiceDeployer) DeployRules() error {
 
 // Deploy Apis into OpenWhisk
 func (deployer *ServiceDeployer) DeployApis() error {
-	for _, api := range deployer.Deployment.Apis {
-		err := deployer.createApi(api)
-		if err != nil {
-			return err
+	var err error
+	// Only deploy either swagger or manifest defined api, but not both
+	// Swagger API takes precedence
+	if deployer.Deployment.SwaggerApi != nil && deployer.Deployment.SwaggerApiOptions != nil {
+		err = deployer.createSwaggerApi(deployer.Deployment.SwaggerApi)
+	} else {
+		for _, api := range deployer.Deployment.Apis {
+			err = deployer.createApi(api)
+			if err != nil {
+				return err
+			}
 		}
 	}
 	return nil
@@ -1035,6 +1044,27 @@ func (deployer *ServiceDeployer) createApi(api *whisk.ApiCreateRequest) error {
 	return nil
 }
 
+// create api (API Gateway functionality) from swagger file
+func (deployer *ServiceDeployer) createSwaggerApi(api *whisk.ApiCreateRequest) error {
+	var err error
+	var response *http.Response
+
+	apiCreateReqOptions := deployer.Deployment.SwaggerApiOptions
+	apiCreateReqOptions.SpaceGuid = strings.Split(deployer.Client.Config.AuthToken, ":")[0]
+	apiCreateReqOptions.AccessToken = deployer.Client.Config.ApigwAccessToken
+
+	err = retry(DEFAULT_ATTEMPTS, DEFAULT_INTERVAL, func() error {
+		_, response, err = deployer.Client.Apis.Insert(api, apiCreateReqOptions, true)
+		return err
+	})
+
+	if err != nil {
+		return createWhiskClientError(err.(*whisk.WskError), response, parsers.YAML_KEY_API, true)
+	}
+
+	return nil
+}
+
 func (deployer *ServiceDeployer) UnDeploy(verifiedPlan *DeploymentProject) error {
 	if deployer.Preview == true {
 		deployer.printDeploymentAssets(verifiedPlan)
@@ -1058,6 +1088,9 @@ func (deployer *ServiceDeployer) UnDeployProject() error {
 }
 
 func (deployer *ServiceDeployer) unDeployAssets(verifiedPlan *DeploymentProject) error {
+	if err := deployer.UndeploySwaggerApis(verifiedPlan); err != nil {
+		return err
+	}
 	if err := deployer.UnDeployApis(verifiedPlan); err != nil {
 		return err
 	}
@@ -1239,6 +1272,15 @@ func (deployer *ServiceDeployer) UnDeployApis(deployment *DeploymentProject) err
 	return nil
 }
 
+func (deployer *ServiceDeployer) UndeploySwaggerApis(deployment *DeploymentProject) error {
+	api := deployment.SwaggerApi
+	err := deployer.deleteSwaggerApi(api)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
 func (deployer *ServiceDeployer) deletePackage(packa *whisk.Package) error {
 
 	displayPreprocessingInfo(parsers.YAML_KEY_PACKAGE, packa.Name, false)
@@ -1396,6 +1438,38 @@ func (deployer *ServiceDeployer) deleteApi(api *whisk.ApiCreateRequest) error {
 		}
 	}
 	displayPostprocessingInfo(parsers.YAML_KEY_API, apiPath, false)
+	return nil
+}
+
+// delete api (API Gateway functionality) from swagger file
+func (deployer *ServiceDeployer) deleteSwaggerApi(api *whisk.ApiCreateRequest) error {
+	var err error
+	var response *http.Response
+
+	swaggerString := api.ApiDoc.Swagger
+	swaggerObj := new(whisk.ApiSwagger)
+	err = json.Unmarshal([]byte(swaggerString), swaggerObj)
+	if err != nil {
+		return err
+	}
+
+	apiDeleteReqOptions := new(whisk.ApiDeleteRequestOptions)
+	apiDeleteReqOptions.SpaceGuid = strings.Split(deployer.Client.Config.AuthToken, ":")[0]
+	apiDeleteReqOptions.AccessToken = deployer.Client.Config.ApigwAccessToken
+	apiDeleteReqOptions.ApiBasePath = swaggerObj.BasePath
+
+	a := new(whisk.ApiDeleteRequest)
+	a.Swagger = swaggerString
+
+	err = retry(DEFAULT_ATTEMPTS, DEFAULT_INTERVAL, func() error {
+		response, err = deployer.Client.Apis.Delete(a, apiDeleteReqOptions)
+		return err
+	})
+
+	if err != nil {
+		return createWhiskClientError(err.(*whisk.WskError), response, parsers.YAML_KEY_API, true)
+	}
+
 	return nil
 }
 

--- a/deployers/servicedeployer.go
+++ b/deployers/servicedeployer.go
@@ -1446,6 +1446,10 @@ func (deployer *ServiceDeployer) deleteSwaggerApi(api *whisk.ApiCreateRequest) e
 	var err error
 	var response *http.Response
 
+	// If there is no swagger file do nothing
+	if api == nil {
+		return nil
+	}
 	swaggerString := api.ApiDoc.Swagger
 	swaggerObj := new(whisk.ApiSwagger)
 	err = json.Unmarshal([]byte(swaggerString), swaggerObj)

--- a/docs/examples/manifest_hello_world_apigateway_open_api_spec.yaml
+++ b/docs/examples/manifest_hello_world_apigateway_open_api_spec.yaml
@@ -1,0 +1,28 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Example: Basic Hello World action with Open API Specification
+project:
+  config: open_api_spec.json
+  packages:
+    hello_world_package:
+      version: 1.0
+      license: Apache-2.0
+      actions:
+        hello_world:
+          function: src/hello.js
+          web-export: true

--- a/docs/examples/open_api_spec.json
+++ b/docs/examples/open_api_spec.json
@@ -1,0 +1,60 @@
+{
+    "swagger": "2.0",
+    "info": {
+        "version": "1.0",
+        "title": "Hello World API"
+    },
+    "basePath": "/hello",
+    "schemes": [
+        "https"
+    ],
+    "consumes": [
+        "application/json"
+    ],
+    "produces": [
+        "application/json"
+    ],
+    "paths": {
+        "/world": {
+            "get": {
+                "description": "Returns a greeting to the user!",
+                "operationId": "hello_world",
+                "responses": {
+                    "200": {
+                        "description": "Returns the greeting.",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        }
+
+    },
+    "x-gateway-configuration": {
+    "assembly": {
+      "execute": [
+        {
+          "operation-switch": {
+            "case": [
+              {
+                "operations": [
+                  "getHello"
+                ],
+                "execute": [
+                  {
+                    "invoke": {
+                      "target-url": "https://openwhisk.ng.bluemix.net/api/some/action/path.http",
+                      "verb": "keep"
+                    }
+                  }
+                ]
+              }
+            ],
+            "otherwise": []
+          }
+        }
+      ]
+    }
+  }
+}

--- a/docs/wskdeploy_apigateway_open_api_spec.md
+++ b/docs/wskdeploy_apigateway_open_api_spec.md
@@ -1,0 +1,177 @@
+<!--
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+-->
+
+# API Gateway
+
+## The "Hello World" API
+
+This example builds on the ["Hello World" Action](wskdeploy_action_helloworld.md#actions) example and ["Hello World" API](wdkdeploy_apigateway_helloworld.md) example by adding an Open API Specification to define an API that is invoked via an API call.
+
+It shows how to:
+- update the Action named ‘hello_world’ to expose it to the gateway.
+- specify the API's endpoint that will trigger the action via an Open API Specification.
+
+### Manifest file
+#### _Example: “Hello world” action with project config to point to the API spec_
+```yaml
+project:
+  config: open_api_spec.json
+  packages:
+    hello_world_package:
+      version: 1.0
+      license: Apache-2.0
+      actions:
+        hello_world:
+          function: src/hello.js
+          web-export: true
+```
+### Open API Specification
+#### _Example: "Hello world" open api specification_
+```json
+{
+    "swagger": "2.0",
+    "info": {
+        "version": "1.0",
+        "title": "Hello World API"
+    },
+    "basePath": "/hello",
+    "schemes": [
+        "https"
+    ],
+    "consumes": [
+        "application/json"
+    ],
+    "produces": [
+        "application/json"
+    ],
+    "paths": {
+        "/world": {
+            "get": {
+                "description": "Returns a greeting to the user!",
+                "operationId": "hello_world",
+                "responses": {
+                    "200": {
+                        "description": "Returns the greeting.",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        }
+
+    },
+    "x-gateway-configuration": {
+    "assembly": {
+      "execute": [
+        {
+          "operation-switch": {
+            "case": [
+              {
+                "operations": [
+                  "getHello"
+                ],
+                "execute": [
+                  {
+                    "invoke": {
+                      "target-url": "https://openwhisk.ng.bluemix.net/api/some/action/path.http",
+                      "verb": "keep"
+                    }
+                  }
+                ]
+              }
+            ],
+            "otherwise": []
+          }
+        }
+      ]
+    }
+  }
+}
+```
+*NOTE*: Some providers such as IBM may have changed these keys. For example, IBM uses `x-ibm-configuration` instead of `x-gateway-configuration`.
+  
+There are two major differences from _"Hello World" API_ example:
+- the root key is now project as the open api specification is a project wide concept.
+- a new `config` key specifying where the Open API Specification is located.
+
+The `config` key under `project` in the manifest file specifies where the Open API Specification is located. The keyword `config` was chosen to remain consistent with the OpenWhisk CLI flag option. The Open API Specification describes in a JSON document the the base path, endpoint, HTTP verb, and other details describing the API. For example, the document above describes a GET endpoint at `/hello/world` that recieves JSON as input and returns JSON as output.
+
+### Deploying
+
+You cannot deploy the "hello world API gateway Open API Specification" manifest from the openwhisk-wskdeploy project directory directly. You need to update the `target-url`. This valued will be specific to your deployment/provider. An example of such a URL would be: `https://us-south.functions.cloud.ibm.com/api/v1/web/jdoe@ibm.com/hello_world_package/hello_world.json`. After filling out that value, you would deploy via:
+
+```sh
+$ wskdeploy -m docs/examples/manifest_hello_world_apigateway_open_api_spec.yaml
+```
+
+### Invoking
+
+Check the full URL of your API first:
+```sh
+$ wsk api list
+```
+
+This will return some information on the API, including the full URL, which
+should end with `hello/world`. It can then be invoked:
+
+```sh
+$ curl <url>
+```
+
+### Result
+The invocation should return a JSON response that includes this result:
+
+```json
+{
+    "greeting": "Hello, undefined from undefined"
+}
+```
+
+The output parameter '```greeting```' contains "_undefined_" values for the '```name```' and '```place```' input parameters as they were not provided in the manifest or the HTTP call. You can provide them as query parameters:
+
+```sh
+$ curl <url>?name=World&place=Earth
+```
+
+### Discussion
+
+This "hello world" example represents the minimum valid Manifest file which includes only the required parts of the Project, Package, Action and Open API Specification location.
+
+### Source code
+The source code for the manifest and JavaScript files can be found here:
+- [manifest_hello_world_apigateway.yaml](examples/manifest_hello_world_apigateway_open_api_spec.yaml)
+- [open_api_spec.json](examples/open_api_spec.json)
+- [hello.js](examples/src/hello.js)
+
+---
+<!--
+ Bottom Navigation
+-->
+<html>
+<div align="center">
+<table align="center">
+  <tr>
+    <td><a href="wskdeploy_triggerrule_trigger_bindings.md#triggers-and-rules">&lt;&lt;&nbsp;previous</a></td>
+    <td><a href="programming_guide.md#guided-examples">Example Index</a></td>
+    <td><a href="wskdeploy_apigateway_sequence.md#api-gateway-sequence">next&nbsp;&gt;&gt;</a></td>
+  </tr>
+</table>
+</div>
+</html>

--- a/docs/wskdeploy_apigateway_open_api_spec.md
+++ b/docs/wskdeploy_apigateway_open_api_spec.md
@@ -106,7 +106,7 @@ project:
 }
 ```
 *NOTE*: Some providers such as IBM may have changed these keys. For example, IBM uses `x-ibm-configuration` instead of `x-gateway-configuration`.
-  
+
 There are two major differences from _"Hello World" API_ example:
 - the root key is now project as the open api specification is a project wide concept.
 - a new `config` key specifying where the Open API Specification is located.

--- a/docs/wskdeploy_apigateway_open_api_spec.md
+++ b/docs/wskdeploy_apigateway_open_api_spec.md
@@ -111,7 +111,7 @@ There are two major differences from _"Hello World" API_ example:
 - the root key is now project as the open api specification is a project wide concept.
 - a new `config` key specifying where the Open API Specification is located.
 
-The `config` key under `project` in the manifest file specifies where the Open API Specification is located. The keyword `config` was chosen to remain consistent with the OpenWhisk CLI flag option. The Open API Specification describes in a JSON document the the base path, endpoint, HTTP verb, and other details describing the API. For example, the document above describes a GET endpoint at `/hello/world` that recieves JSON as input and returns JSON as output.
+The `config` key under `project` in the manifest file specifies where the Open API Specification is located. The keyword `config` was chosen to remain consistent with the `config-file` terminology in OpenWhisk CLI flag option. The Open API Specification describes in a JSON document the the base path, endpoint, HTTP verb, and other details describing the API. For example, the document above describes a GET endpoint at `/hello/world` that recieves JSON as input and returns JSON as output.
 
 ### Deploying
 

--- a/docs/wskdeploy_apigateway_open_api_spec.md
+++ b/docs/wskdeploy_apigateway_open_api_spec.md
@@ -17,7 +17,7 @@
 #
 -->
 
-# API Gateway
+# API Open API Spec
 
 ## The "Hello World" API
 

--- a/parsers/manifest_parser.go
+++ b/parsers/manifest_parser.go
@@ -19,6 +19,7 @@ package parsers
 
 import (
 	"encoding/base64"
+	"encoding/json"
 	"errors"
 	"io/ioutil"
 	"os"
@@ -38,6 +39,7 @@ import (
 	"github.com/apache/openwhisk-wskdeploy/wskenv"
 	"github.com/apache/openwhisk-wskdeploy/wski18n"
 	"github.com/apache/openwhisk-wskdeploy/wskprint"
+	yamlHelper "github.com/ghodss/yaml"
 	"net/url"
 )
 
@@ -54,6 +56,9 @@ const (
 	PARAM_CLOSING_BRACKET = "}"
 
 	DUMMY_APIGW_ACCESS_TOKEN = "DUMMY TOKEN"
+
+	YAML_FILE_EXTENSION = "yaml"
+	YML_FILE_EXTENSION  = "yml"
 )
 
 // Read existing manifest file or create new if none exists
@@ -1297,6 +1302,111 @@ func (dm *YAMLParser) ComposeApiRecords(client *whisk.Config, packageName string
 		}
 	}
 	return requests, requestOptions, nil
+}
+
+func (dm *YAMLParser) ComposeApiRecordsFromSwagger(client *whisk.Config, manifest *YAML) (*whisk.ApiCreateRequest, *whisk.ApiCreateRequestOptions, error) {
+	var api *whisk.Api
+	var err error
+	var config string = manifest.Project.Config
+	// Check to make sure the manifest has a config under project
+	if config == "" {
+		return nil, nil, nil
+	}
+
+	api, err = dm.parseSwaggerApi(config, client.Namespace)
+	if err != nil {
+		whisk.Debug(whisk.DbgError, "parseSwaggerApi() error: %s\n", err)
+		errMsg := wski18n.T("Unable to parse swagger file: {{.err}}", map[string]interface{}{"err": err})
+		whiskErr := whisk.MakeWskErrorFromWskError(errors.New(errMsg), err, whisk.EXIT_CODE_ERR_GENERAL,
+			whisk.DISPLAY_MSG, whisk.DISPLAY_USAGE)
+		return nil, nil, whiskErr
+	}
+
+	apiCreateReq := new(whisk.ApiCreateRequest)
+	apiCreateReq.ApiDoc = api
+
+	apiCreateReqOptions := new(whisk.ApiCreateRequestOptions)
+
+	return apiCreateReq, apiCreateReqOptions, nil
+
+}
+
+/*
+ * Read the swagger config provided by under
+ * Project:
+ *   config: swagger_filename.[yaml|yml]
+ *
+ * NOTE: This was lifted almost verbatim from openwhisk-cli/commands/api.go
+ *       and as a follow up should probably be moved and updated to live in whiskclient-go
+ * NOTE: This does notb verify that actions used in swagger api definition are defined in
+ *        the openwhisk server or manifest.
+ */
+func (dm *YAMLParser) parseSwaggerApi(configfile, namespace string) (*whisk.Api, error) {
+	if len(configfile) == 0 {
+		whisk.Debug(whisk.DbgError, "No swagger file is specified\n")
+		errMsg := wski18n.T("A swagger configuration file was not specified.")
+		whiskErr := whisk.MakeWskError(errors.New(errMsg), whisk.EXIT_CODE_ERR_GENERAL,
+			whisk.DISPLAY_MSG, whisk.DISPLAY_USAGE)
+		return nil, whiskErr
+	}
+
+	swagger, err := ioutil.ReadFile(configfile)
+	if err != nil {
+		whisk.Debug(whisk.DbgError, "readFile(%s) error: %s\n", configfile, err)
+		errMsg := wski18n.T("Error reading swagger file '{{.name}}': {{.err}}",
+			map[string]interface{}{"name": configfile, "err": err})
+		whiskErr := whisk.MakeWskErrorFromWskError(errors.New(errMsg), err, whisk.EXIT_CODE_ERR_GENERAL,
+			whisk.DISPLAY_MSG, whisk.DISPLAY_USAGE)
+		return nil, whiskErr
+	}
+
+	// Check if this swagger is in JSON or YAML format
+	isYaml := strings.HasSuffix(configfile, YAML_FILE_EXTENSION) || strings.HasSuffix(configfile, YML_FILE_EXTENSION)
+	if isYaml {
+		whisk.Debug(whisk.DbgInfo, "Converting YAML formated API configuration into JSON\n")
+		jsonbytes, err := yamlHelper.YAMLToJSON([]byte(swagger))
+		if err != nil {
+			whisk.Debug(whisk.DbgError, "yaml.YAMLToJSON() error: %s\n", err)
+			errMsg := wski18n.T("Unable to parse YAML configuration file: {{.err}}", map[string]interface{}{"err": err})
+			whiskErr := whisk.MakeWskError(errors.New(errMsg), whisk.EXIT_CODE_ERR_GENERAL,
+				whisk.DISPLAY_MSG, whisk.NO_DISPLAY_USAGE)
+			return nil, whiskErr
+		}
+		swagger = jsonbytes
+	}
+
+	// Parse the JSON into a swagger object
+	swaggerObj := new(whisk.ApiSwagger)
+	err = json.Unmarshal([]byte(swagger), swaggerObj)
+	if err != nil {
+		whisk.Debug(whisk.DbgError, "JSON parse of '%s' error: %s\n", configfile, err)
+		errMsg := wski18n.T("Error parsing swagger file '{{.name}}': {{.err}}",
+			map[string]interface{}{"name": configfile, "err": err})
+		whiskErr := whisk.MakeWskErrorFromWskError(errors.New(errMsg), err, whisk.EXIT_CODE_ERR_GENERAL,
+			whisk.DISPLAY_MSG, whisk.DISPLAY_USAGE)
+		return nil, whiskErr
+	}
+	if swaggerObj.BasePath == "" || swaggerObj.SwaggerName == "" || swaggerObj.Info == nil || swaggerObj.Paths == nil {
+		whisk.Debug(whisk.DbgError, "Swagger file is invalid.\n")
+		errMsg := wski18n.T("Swagger file is invalid (missing basePath, info, paths, or swagger fields)")
+		whiskErr := whisk.MakeWskError(errors.New(errMsg), whisk.EXIT_CODE_ERR_GENERAL,
+			whisk.DISPLAY_MSG, whisk.DISPLAY_USAGE)
+		return nil, whiskErr
+	}
+
+	if !strings.HasPrefix(swaggerObj.BasePath, "/") {
+		whisk.Debug(whisk.DbgError, "Swagger file basePath is invalid.\n")
+		errMsg := wski18n.T("Swagger file basePath must start with a leading slash (/)")
+		whiskErr := whisk.MakeWskError(errors.New(errMsg), whisk.EXIT_CODE_ERR_GENERAL,
+			whisk.DISPLAY_MSG, whisk.DISPLAY_USAGE)
+		return nil, whiskErr
+	}
+
+	api := new(whisk.Api)
+	api.Namespace = namespace
+	api.Swagger = string(swagger)
+
+	return api, nil
 }
 
 func (dm *YAMLParser) getGatewayMethods() []string {

--- a/parsers/yamlparser.go
+++ b/parsers/yamlparser.go
@@ -233,6 +233,7 @@ type Project struct {
 	Version          string               `yaml:"version"`
 	Packages         map[string]Package   `yaml:"packages"`
 	Inputs           map[string]Parameter `yaml: parameters`
+	Config           string               `yaml:"config"`
 }
 
 type YAML struct {


### PR DESCRIPTION
  Adds the ability for swagger file specifying the api to be
  referenced in the manifest under project.config. The config
  name was chosen to be consistent with whisk-cli -c/--config
  option.

Note: I'll be adding a few documentation updates at the end of the day