### PR TITLE
Remove misleading web-export key

### DIFF
--- a/docs/examples/manifest_hello_world_apigateway.yaml
+++ b/docs/examples/manifest_hello_world_apigateway.yaml
@@ -23,7 +23,8 @@ packages:
     actions:
       hello_world:
         function: src/hello.js
-        web-export: true
+        annotations:
+          web-export: true
     apis:
       hello-world:
         hello:

--- a/docs/examples/manifest_hello_world_apigateway_http.yaml
+++ b/docs/examples/manifest_hello_world_apigateway_http.yaml
@@ -23,10 +23,12 @@ packages:
     actions:
       hello_world:
         function: src/hello_http.js
-        web-export: true
+        annotations:
+          web-export: true
       hello_world_promise:
         function: src/hello_http_promise.js
-        web-export: true
+        annotations:
+          web-export: true
     apis:
       hello-world:
         hello:

--- a/docs/examples/manifest_hello_world_apigateway_open_api_spec.yaml
+++ b/docs/examples/manifest_hello_world_apigateway_open_api_spec.yaml
@@ -25,4 +25,5 @@ project:
       actions:
         hello_world:
           function: src/hello.js
+        annotations:
           web-export: true

--- a/docs/export.md
+++ b/docs/export.md
@@ -191,13 +191,13 @@ packages:
         namespace: your_namespace/lib1_package
         credential: ""
         exposedUrl: ""
-        web-export: ""
         main: ""
         limits: null
         inputs: {}
         outputs: {}
         annotations:
           exec: nodejs:default
+          web-export: ""
       lib1_greeting2:
         name: lib1_greeting2
         location: ""
@@ -208,13 +208,13 @@ packages:
         namespace: your_namespace/lib1_package
         credential: ""
         exposedUrl: ""
-        web-export: ""
         main: ""
         limits: null
         inputs: {}
         outputs: {}
         annotations:
           exec: nodejs:default
+          web-export: ""
       lib1_greeting3:
         name: lib1_greeting3
         location: ""

--- a/docs/wskdeploy_apigateway_helloworld.md
+++ b/docs/wskdeploy_apigateway_helloworld.md
@@ -37,7 +37,8 @@ packages:
     actions:
       hello_world:
         function: src/hello.js
-        web-export: true
+        annotations:
+          web-export: true
     apis:
       hello-world:
         hello:
@@ -47,7 +48,7 @@ packages:
 ```
 
 There are two key changes to this file:
-- the `hello_world` action now has the `web-export` flag set to `true`.
+- the `hello_world` action now has the `web-export` annotation set to `true`.
 - a new `apis` block has been created.
 
 The `apis` block contains a number of groups of API endpoint. Each endpoint is then defined by the hierarchy. In this case, we are creating the `hello/world` endpoint. The leaf in the structure specifies the action to trigger when the given HTTP verb is sent to that endpoint, in this case, when the HTTP verb `GET` is used on the `hello/world` endpoint, trigger the `hello_world` action.

--- a/docs/wskdeploy_apigateway_open_api_spec.md
+++ b/docs/wskdeploy_apigateway_open_api_spec.md
@@ -39,6 +39,7 @@ project:
       actions:
         hello_world:
           function: src/hello.js
+        annotations:
           web-export: true
 ```
 ### Open API Specification

--- a/parsers/yamlparser.go
+++ b/parsers/yamlparser.go
@@ -255,9 +255,6 @@ type PackageInputs struct {
 // function to return web-export or web depending on what is specified
 // in manifest and deployment files. Web flag takes precedence.
 func (action *Action) GetWeb() string {
-	if len(action.Web) == 0 && len(action.WebExport) != 0 {
-		return action.WebExport
-	}
 	return action.Web
 }
 

--- a/parsers/yamlparser.go
+++ b/parsers/yamlparser.go
@@ -109,7 +109,7 @@ type Action struct {
 	Main        string                 `yaml:"main"`
 	Docker      string                 `yaml:"docker,omitempty"`
 	Native      bool                   `yaml:"native,omitempty"`
-	Conductor   bool               	   `yaml:"conductor,omitempty"`
+	Conductor   bool                   `yaml:"conductor,omitempty"`
 	Limits      *Limits                `yaml:"limits"`
 	Inputs      map[string]Parameter   `yaml:"inputs"`
 	Outputs     map[string]Parameter   `yaml:"outputs"`
@@ -255,6 +255,9 @@ type PackageInputs struct {
 // function to return web-export or web depending on what is specified
 // in manifest and deployment files. Web flag takes precedence.
 func (action *Action) GetWeb() string {
+	if len(action.Web) == 0 && len(action.WebExport) != 0 {
+		return action.WebExport
+	}
 	return action.Web
 }
 

--- a/specification/html/spec_actions.md
+++ b/specification/html/spec_actions.md
@@ -42,7 +42,7 @@ The Action entity schema contains the necessary information to deploy an OpenWhi
 | outputs | no | list of [parameter](spec_parameters.md) | N/A | The optional outputs from the Action. |
 | limits | no | map of [limit keys and values](#valid-limit-keys) | N/A | Optional map of limit keys and their values.</br>See section "[Valid limit keys](#valid-limit-keys)" (below) for a listing of recognized keys and values. |
 | feed | no | boolean | false | Optional indicator that the Action supports the required parameters (and operations) to be run as a Feed Action. |
-| web&nbsp;&#124; web-export | no | string | true&nbsp;&#124; false&nbsp;&#124; yes&nbsp;&#124; no&nbsp;&#124; raw | The optional flag that makes the action accessible to REST calls without authentication.<p>For details on all types of Web Actions, see: [Web Actions](https://github.com/apache/openwhisk/blob/master/docs/webactions.md).</p>|
+| web | no | string | true&nbsp;&#124; false&nbsp;&#124; yes&nbsp;&#124; no&nbsp;&#124; raw | The optional flag that makes the action accessible to REST calls without authentication.<p>For details on all types of Web Actions, see: [Web Actions](https://github.com/apache/openwhisk/blob/master/docs/webactions.md).</p>|
 | raw-http | no | boolean | false | The optional flag (annotation) to indicate if a Web Action is able to consume the raw contents within the body of an HTTP request.<p><b>Note</b>: this option is ONLY valid if <em>"web"</em> or <em>"web-export"</em> is set to <em>‘true’</em>.<p> |
 | docker | no | string | N/A | The optional key that references a Docker image (e.g., openwhisk/skeleton). |
 | native | no | boolean | false | The optional key (flag) that indicates the Action is should use the Docker skeleton image for OpenWhisk (i.e., short-form for docker: openwhisk/skeleton). |
@@ -78,7 +78,7 @@ The following annotations have special meanings for Actions:
 - When the `code` key-value is specified, the `runtime` **SHALL** be a required field.
 
 #### Annotation requirements
-- The annotation `require-whisk-auth` **SHALL** only be valid for web actions (i.e., if the `web` or `web-export` key (or `web-export` annotation) is set to `true`).
+- The annotation `require-whisk-auth` **SHALL** only be valid for web actions (i.e., if the `web` key or `web-export` annotation is set to `true`).
 - If the value of the `require-whisk-auth` annotation is an `integer` its value **MUST** be a positive integer less than or equal to the `MAX_INT` value of `9007199254740991`.
 - When the `web` or `web-export` key is present and set to `true` the web action's **MUST** also be marked `final`.  This happens automatically when the `web` or `web-export` keys are present and set to `true`.
 

--- a/specification/html/spec_apis.md
+++ b/specification/html/spec_apis.md
@@ -79,7 +79,8 @@ packages:
     actions:
       hello_world:
         function: src/hello.js
-        web-export: true
+        annotations:
+          web-export: true
     apis:
       hello-world:
         hello:

--- a/tests/dat/manifest_data_compose_actions_for_invalid_web.yaml
+++ b/tests/dat/manifest_data_compose_actions_for_invalid_web.yaml
@@ -20,4 +20,5 @@ packages:
     actions:
       hello:
         function: ../tests/src/integration/helloworld/actions/hello.js
-        web-export: raw123
+        annotations:
+          web-export: raw123

--- a/tests/dat/manifest_data_compose_actions_for_web.yaml
+++ b/tests/dat/manifest_data_compose_actions_for_web.yaml
@@ -20,16 +20,21 @@ packages:
     actions:
       hello1:
         function: ../src/integration/helloworld/actions/hello.js
-        web-export: true
+        annotations:
+          web-export: true
       hello2:
         function: ../src/integration/helloworld/actions/hello.js
-        web-export: yes
+        annotations:
+          web-export: yes
       hello3:
         function: ../src/integration/helloworld/actions/hello.js
-        web-export: raw
+        annotations:
+          web-export: raw
       hello4:
         function: ../src/integration/helloworld/actions/hello.js
-        web-export: false
+        annotations:
+          web-export: false
       hello5:
         function: ../src/integration/helloworld/actions/hello.js
-        web-export: no
+        annotations:
+          web-export: no

--- a/tests/dat/manifest_data_compose_actions_for_web.yaml
+++ b/tests/dat/manifest_data_compose_actions_for_web.yaml
@@ -20,21 +20,17 @@ packages:
     actions:
       hello1:
         function: ../src/integration/helloworld/actions/hello.js
-        annotations:
-          web-export: true
+        web-export: true
       hello2:
         function: ../src/integration/helloworld/actions/hello.js
-        annotations:
-          web-export: yes
+        web-export: yes
       hello3:
         function: ../src/integration/helloworld/actions/hello.js
-        annotations:
-          web-export: raw
+        web-export: raw
       hello4:
         function: ../src/integration/helloworld/actions/hello.js
-        annotations:
-          web-export: false
+        web-export: false
       hello5:
         function: ../src/integration/helloworld/actions/hello.js
-        annotations:
-          web-export: no
+        web-export: no
+

--- a/tests/dat/manifest_data_compose_actions_for_web_and_web_export.yaml
+++ b/tests/dat/manifest_data_compose_actions_for_web_and_web_export.yaml
@@ -22,19 +22,23 @@ packages:
         function: ../src/integration/helloworld/actions/hello.js
         runtime: nodejs
         web: true
-        web-export: true
+        annotations:
+          web-export: true
       hello2:
         function: ../src/integration/helloworld/actions/hello.js
         runtime: nodejs
         web: true
-        web-export: false
+        annotations:
+          web-export: false
       hello3:
         function: ../src/integration/helloworld/actions/hello.js
         runtime: nodejs
         web: false
-        web-export: true
+        annotations:
+          web-export: true
       hello4:
         function: ../src/integration/helloworld/actions/hello.js
         runtime: nodejs
         web: raw
-        web-export: true
+        annotations:
+          web-export: true

--- a/tests/dat/manifest_data_compose_api_records.yaml
+++ b/tests/dat/manifest_data_compose_api_records.yaml
@@ -20,7 +20,8 @@ packages:
         actions:
             putBooks:
                 function: ../tests/src/integration/helloworld/actions/hello.js
-                web-export: true
+                annotations:
+                    web-export: true
             deleteBooks:
                 function: ../tests/src/integration/helloworld/actions/hello.js
             listMembers:

--- a/tests/src/integration/apigateway/manifest.yml
+++ b/tests/src/integration/apigateway/manifest.yml
@@ -21,7 +21,8 @@ packages:
         license: Apache-2.0
         actions:
             greeting:
-                web-export: true
+                annotations:
+                    web-export: true
                 version: 1.0
                 function: src/greeting.js
                 runtime: nodejs:default

--- a/tests/src/integration/defaultpackage/manifest-with-project.yaml
+++ b/tests/src/integration/defaultpackage/manifest-with-project.yaml
@@ -23,7 +23,8 @@ project:
                 helloInDefaultPackage:
                     function: actions/hello.js
                     runtime: nodejs:default
-                    web-export: true
+                    annotations:
+                        web-export: true
                     inputs:
                         name:
                             type: string
@@ -82,7 +83,8 @@ project:
                 greetingInsidePackage:
                     function: actions/hello.js
                     runtime: nodejs:default
-                    web-export: true
+                    annotations:
+                        web-export: true
                     inputs:
                         name:
                             type: string

--- a/tests/src/integration/defaultpackage/manifest.yaml
+++ b/tests/src/integration/defaultpackage/manifest.yaml
@@ -21,7 +21,8 @@ packages:
             helloInDefaultPackage:
                 function: actions/hello.js
                 runtime: nodejs:default
-                web-export: true
+                annotations:
+                    web-export: true
                 inputs:
                     name:
                         type: string
@@ -80,7 +81,8 @@ packages:
             greetingInsidePackage:
                 function: actions/hello.js
                 runtime: nodejs:default
-                web-export: true
+                annotations:
+                    web-export: true
                 inputs:
                     name:
                         type: string

--- a/tests/src/integration/export/manifest_apiexp.yaml
+++ b/tests/src/integration/export/manifest_apiexp.yaml
@@ -21,7 +21,8 @@ packages:
         license: Apache-2.0
         actions:
             greeting:
-                web-export: true
+                annotations:
+                    web-export: true
                 version: 1.0
                 function: src/greeting.js
                 runtime: nodejs:default

--- a/tests/src/integration/flagstests/manifest.yaml
+++ b/tests/src/integration/flagstests/manifest.yaml
@@ -21,7 +21,8 @@ packages:
       license: Apache-2.0
       actions:
         greeting:
-          web-export: true
+          annotations:
+            web-export: true
           version: 1.0
           function: src/greeting.js
           runtime: nodejs:default

--- a/tests/src/integration/flagstests/manifest.yml
+++ b/tests/src/integration/flagstests/manifest.yml
@@ -21,7 +21,8 @@ packages:
       license: Apache-2.0
       actions:
         greeting:
-          web-export: true
+          annotations:
+            web-export: true
           version: 1.0
           function: src/greeting.js
           runtime: nodejs:default

--- a/tests/src/integration/runtimetests/manifest.yaml
+++ b/tests/src/integration/runtimetests/manifest.yaml
@@ -21,7 +21,8 @@ packages:
         license: Apache-1.0
         actions:
             greetingnodejs6-with-explicit-runtime:
-                web-export: true
+                annotations:
+                    web-export: true
                 version: 1.0
                 function: src/greeting.js
                 runtime: nodejs:default
@@ -31,7 +32,8 @@ packages:
                 outputs:
                     payload: string
             greetingnodejs8-with-explicit-runtime:
-                web-export: true
+                annotations:
+                    web-export: true
                 version: 1.0
                 function: src/greeting.js
                 runtime: nodejs:8
@@ -41,7 +43,8 @@ packages:
                 outputs:
                     payload: string
             greetingnodejs10-with-explicit-runtime:
-                web-export: true
+                annotations:
+                    web-export: true
                 version: 1.0
                 function: src/greeting.js
                 runtime: nodejs:10
@@ -51,7 +54,8 @@ packages:
                 outputs:
                     payload: string
             greetingphp71-with-explicit-runtime:
-                web-export: true
+                annotations:
+                    web-export: true
                 version: 1.0
                 function: src/hello.php
                 runtime: php:7.1
@@ -61,7 +65,8 @@ packages:
                 outputs:
                     payload: string
             greetingphp72-with-explicit-runtime:
-                web-export: true
+                annotations:
+                    web-export: true
                 version: 1.0
                 function: src/hello.php
                 runtime: php:7.2
@@ -71,7 +76,8 @@ packages:
                 outputs:
                     payload: string
             greetingphp73-with-explicit-runtime:
-                web-export: true
+                annotations:
+                    web-export: true
                 version: 1.0
                 function: src/hello.php
                 runtime: php:7.3
@@ -81,7 +87,8 @@ packages:
                 outputs:
                     payload: string
             greetingpython-with-explicit-runtime:
-                web-export: true
+                annotations:
+                    web-export: true
                 version: 1.0
                 function: src/hello.py
                 runtime: python
@@ -91,7 +98,8 @@ packages:
                 outputs:
                     payload: string
             greetingpython2-with-explicit-runtime:
-                web-export: true
+                annotations:
+                    web-export: true
                 version: 1.0
                 function: src/hello.py
                 runtime: python:2
@@ -101,7 +109,8 @@ packages:
                 outputs:
                     payload: string
             greetingpython3-with-explicit-runtime:
-                web-export: true
+                annotations:
+                    web-export: true
                 version: 1.0
                 function: src/hello.py
                 runtime: python:3
@@ -111,7 +120,8 @@ packages:
                 outputs:
                     payload: string
             greetingruby25-with-explicit-runtime:
-                web-export: true
+                annotations:
+                    web-export: true
                 version: 1.0
                 function: src/hello.rb
                 runtime: ruby:2.5
@@ -121,7 +131,8 @@ packages:
                 outputs:
                     payload: string
             greetingswift42-with-explicit-runtime:
-                web-export: true
+                annotations:
+                    web-export: true
                 version: 1.0
                 function: src/hello.swift
                 runtime: swift:4.2
@@ -149,7 +160,8 @@ packages:
     TestImplicitRuntimes:
         actions:
             greetingnodejs-without-explicit-runtime:
-                web-export: true
+                annotations:
+                    web-export: true
                 version: 1.0
                 function: src/greeting.js
                 inputs:
@@ -158,7 +170,8 @@ packages:
                 outputs:
                     payload: string
             greetingphp-without-explicit-runtime:
-                web-export: true
+                annotations:
+                    web-export: true
                 version: 1.0
                 function: src/hello.php
                 inputs:
@@ -167,7 +180,8 @@ packages:
                 outputs:
                     payload: string
             greetingpython-without-explicit-runtime:
-                web-export: true
+                annotations:
+                    web-export: true
                 version: 1.0
                 function: src/hello.py
                 inputs:
@@ -176,7 +190,8 @@ packages:
                 outputs:
                     payload: string
             greetingruby-without-explicit-runtime:
-                web-export: true
+                annotations:
+                    web-export: true
                 version: 1.0
                 function: src/hello.rb
                 inputs:
@@ -185,7 +200,8 @@ packages:
                 outputs:
                     payload: string
             greetingswift-without-explicit-runtime:
-                web-export: true
+                annotations:
+                    web-export: true
                 version: 1.0
                 function: src/hello.swift
                 inputs:
@@ -199,7 +215,8 @@ packages:
     TestInvalidExplicitRuntimes:
         actions:
             greetingnodejs-with-java-explicit-runtime:
-                web-export: true
+                annotations:
+                    web-export: true
                 version: 1.0
                 function: src/greeting.js
                 runtime: java
@@ -209,7 +226,8 @@ packages:
                 outputs:
                     payload: string
             greetingnodejs-with-random-explicit-runtime:
-                web-export: true
+                annotations:
+                    web-export: true
                 version: 1.0
                 function: src/greeting.js
                 runtime: random
@@ -219,7 +237,8 @@ packages:
                 outputs:
                     payload: string
             greetingphp-with-nodejs-explicit-runtime:
-                web-export: true
+                annotations:
+                    web-export: true
                 version: 1.0
                 function: src/hello.php
                 runtime: nodejs:default
@@ -229,7 +248,8 @@ packages:
                 outputs:
                     payload: string
             greetingphp-with-random-explicit-runtime:
-                web-export: true
+                annotations:
+                    web-export: true
                 version: 1.0
                 function: src/hello.php
                 runtime: random
@@ -239,7 +259,8 @@ packages:
                 outputs:
                     payload: string
             greetingpython-with-php-explicit-runtime:
-                web-export: true
+                annotations:
+                    web-export: true
                 version: 1.0
                 function: src/hello.py
                 runtime: php
@@ -249,7 +270,8 @@ packages:
                 outputs:
                     payload: string
             greetingpython-with-random-explicit-runtime:
-                web-export: true
+                annotations:
+                    web-export: true
                 version: 1.0
                 function: src/hello.py
                 runtime: random
@@ -259,7 +281,8 @@ packages:
                 outputs:
                     payload: string
             greetingruby-with-php-explicit-runtime:
-                web-export: true
+                annotations:
+                    web-export: true
                 version: 1.0
                 function: src/hello.rb
                 runtime: php
@@ -269,7 +292,8 @@ packages:
                 outputs:
                     payload: string
             greetingruby-with-random-explicit-runtime:
-                web-export: true
+                annotations:
+                    web-export: true
                 version: 1.0
                 function: src/hello.rb
                 runtime: random
@@ -279,7 +303,8 @@ packages:
                 outputs:
                     payload: string
             greetingswift-with-nodejs-explicit-runtime:
-                web-export: true
+                annotations:
+                    web-export: true
                 version: 1.0
                 function: src/hello.swift
                 runtime: nodejs:default
@@ -289,7 +314,8 @@ packages:
                 outputs:
                     payload: string
             greetingswift-with-random-explicit-runtime:
-                web-export: true
+                annotations:
+                    web-export: true
                 version: 1.0
                 function: src/hello.swift
                 runtime: random

--- a/tests/src/integration/webaction/manifest.yml
+++ b/tests/src/integration/webaction/manifest.yml
@@ -20,7 +20,8 @@ packages:
     IntegrationTestWebAction:
         actions:
             greeting-web-action:
-                web-export: true
+                annotations:
+                    web-export: true
                 version: 1.0
                 function: src/greeting.js
                 runtime: nodejs:default
@@ -30,7 +31,8 @@ packages:
                 outputs:
                     payload: string
             greeting-web-action-1:
-                web-export: yes
+                annotations:
+                    web-export: yes
                 version: 1.0
                 function: src/greeting.js
                 runtime: nodejs:default
@@ -40,19 +42,22 @@ packages:
                 outputs:
                     payload: string
             greeting-with-raw-http:
-                web-export: raw
+                annotations:
+                    web-export: raw
                 version: 1.0
                 function: src/greeting.js
                 runtime: nodejs:default
             greeting-web-action-final:
-                web-export: true
+                annotations:
+                    web-export: true
                 version: 1.0
                 function: src/greeting.js
                 runtime: nodejs:default
                 annotations:
                     final: true
             greeting-web-action-with-custom-options:
-                web-export: true
+                annotations:
+                    web-export: true
                 version: 1.0
                 function: src/greeting.js
                 runtime: nodejs:default


### PR DESCRIPTION
`web-export(key)` is being interchangeably used with `web` in `wskdeploy`.
On the other hand, it is differently used in `wsk` cli.

For example, if the `web` flag is enabled OW will make the action as a web action and enable the `final` flag. To avoid the use of protected parameters, users can configure two annotations, `web-export(true)` and `final(false)` flag.

But with `wskdeploy`, `web-export` is also being used as a top key of actions and it enables the `final` flag all the time.

Even if users still can control this with annotations, I think it is misleading to have the same option in two different places with two different meanings.

So I removed the top-level one.


