### PR TITLE
Remove unsupported Darwin-386 (23-bit) from GoLang 1.15 build matrix

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -213,7 +213,7 @@ if (rootProject.hasProperty('buildPlatforms')) {
         rootProject.ext.platforms = [
                 'linux-386', 'linux-amd64',
                 'linux-s390x', 'linux-ppc64le', 'linux-arm', 'linux-arm64',
-                'darwin-386', 'darwin-amd64',
+                'darwin-amd64',
                 'windows-386', 'windows-amd64'
         ].collect { new OpenWhiskPlatform(it) }
     } else {


### PR DESCRIPTION
The wskdeploy (release, non-PR) builds including "latest" have been failing since upgrading to GoLang 1.15 since the 32-bit architecture is no longer supported for Darwin as a decision from the golang project.  

See "remove darwin 386" PR: https://github.com/golang/go/issues/37610

I am removing it from our gradle build matrix to hopefully get our binary release builds running again...