### PR TITLE
Fix gogradle plugin to stop using vendor directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,6 @@ git clone --branch 1.1.0 git@github.com:apache/openwhisk-wskdeploy
 
 You can also pull the code from a fork of the repository. If you intend to become a Contributor to the project, read the section [Contributing to the project](#contributing-to-the-project) below on how to setup a fork.
 
-
 ### Building using `go build`
 
 Use the Go utility to build the ```wskdeploy``` binary
@@ -149,20 +148,21 @@ After compiling, a suitable wskdeploy binary that works for your OS platform wil
 
 1. First you need a docker daemon running locally on your machine.
 
-2. Make sure you have Java 8 or above installed.
+1. Make sure you have Java 8 or above installed.
 
-3. Clone the wskdeploy repo with command ```git clone https://github.com/apache/openwhisk-wskdeploy.git```
+1. Clone the wskdeploy repo with command ```git clone https://github.com/apache/openwhisk-wskdeploy.git```
 
-4. If you use Windows OS, type ```gradlew.bat -version ```. For Unix/Linux/Mac, please type ```./gradlew -version```.
+1. Verify your installed Gradle version is `5.5.1` (or higher)
 
-5. Make sure you can see the correct Gradle version info on your console.
+    - If you use Windows OS, type ```gradlew.bat -version ```.
+    - For Unix/Linux/Mac, please type ```./gradlew -version```.
 
-> Currently the expected Gradle version is `5.5.1`
+    > **Note** Gradle v6 is not yet supported.
 
-6. For Windows type ```gradlew.bat distDocker```. For Linux/Unix/Mac, please type ```./gradlew distDocker```. These
+1. For Windows type ```gradlew.bat distDocker```. For Linux/Unix/Mac, please type ```./gradlew distDocker```. These
 commands will start the wskdeploy cross compile for your specific OS platform inside a Docker container.
 
-7. After build success, you should find a correct binary under current /bin dir of you openwhisk-deploy clone dir.
+1. After build success, you should find a correct binary under current /bin dir of you openwhisk-deploy clone dir.
 
 If you would like to build the binaries available for all the operating systems and architectures, run the following command:
 

--- a/README.md
+++ b/README.md
@@ -155,8 +155,9 @@ After compiling, a suitable wskdeploy binary that works for your OS platform wil
 
 4. If you use Windows OS, type ```gradlew.bat -version ```. For Unix/Linux/Mac, please type ```./gradlew -version```.
 
-5. Make sure you can see the correct Gradle version info on your console. Currently the expected Gradle
-version is 3.3.
+5. Make sure you can see the correct Gradle version info on your console.
+
+> Currently the expected Gradle version is `5.5.1`
 
 6. For Windows type ```gradlew.bat distDocker```. For Linux/Unix/Mac, please type ```./gradlew distDocker```. These
 commands will start the wskdeploy cross compile for your specific OS platform inside a Docker container.

--- a/build.gradle
+++ b/build.gradle
@@ -37,6 +37,7 @@ golang {
     buildTags = (rootProject.findProperty('goTags')?:'').split(',')
 }
 
+/*
 dependencies {
     golang {
         build(['name':'github.com/cloudfoundry/jibber_jabber', 'version':'bcc4c8345a21301bf47c032ff42dd1aae2fe3027', 'transitive':false])
@@ -84,6 +85,7 @@ dependencies {
 
     }
 }
+*/
 
 rat {
     excludes += [

--- a/build.gradle
+++ b/build.gradle
@@ -37,6 +37,23 @@ golang {
     buildTags = (rootProject.findProperty('goTags')?:'').split(',')
 }
 
+// The `gogradle` plugin was designed to work with govendor and godeps
+// We must disable its tasks that attempt to "fetch" dpendendencies
+// into a "/vendor" directory and use them to build the project (which will fail)
+installDependencies.enabled = false
+resolveBuildDependencies.enabled = false
+
+// try overwriting the task (make sure to test well the App afterwards to avoid unwanted side-effects).
+// In order to you should do the following:
+
+// task(overwrite: true){
+// apply plugin: 'com.name.of.your.plugin'
+// plugin {
+//     defaultConfig {
+
+//     }
+// }}
+
 /*
 dependencies {
     golang {

--- a/build.gradle
+++ b/build.gradle
@@ -43,67 +43,7 @@ golang {
 installDependencies.enabled = false
 resolveBuildDependencies.enabled = false
 
-// try overwriting the task (make sure to test well the App afterwards to avoid unwanted side-effects).
-// In order to you should do the following:
-
-// task(overwrite: true){
-// apply plugin: 'com.name.of.your.plugin'
-// plugin {
-//     defaultConfig {
-
-//     }
-// }}
-
-/*
-dependencies {
-    golang {
-        build(['name':'github.com/cloudfoundry/jibber_jabber', 'version':'bcc4c8345a21301bf47c032ff42dd1aae2fe3027', 'transitive':false])
-        build(['name':'github.com/fatih/color', 'version':'570b54cabe6b8eb0bc2dfce68d964677d63b5260', 'transitive':false])
-        build(['name':'github.com/fsnotify/fsnotify', 'version':'fd9ec7deca8bf46ecd2a795baaacf2b3a9be1197', 'transitive':false])
-        build(['name':'github.com/google/go-querystring/query', 'version':'9235644dd9e52eeae6fa48efd539fdc351a0af53', 'transitive':false])
-        build(['name':'github.com/hashicorp/hcl', 'version':'973f376f0e7cf09c96e445b44712416c0cb22ec4', 'transitive':false])
-        build(['name':'github.com/hashicorp/hcl/hcl/ast', 'version':'973f376f0e7cf09c96e445b44712416c0cb22ec4', 'transitive':false])
-        build(['name':'github.com/hashicorp/hcl/hcl/parser', 'version':'973f376f0e7cf09c96e445b44712416c0cb22ec4', 'transitive':false])
-        build(['name':'github.com/hashicorp/hcl/hcl/scanner', 'version':'973f376f0e7cf09c96e445b44712416c0cb22ec4', 'transitive':false])
-        build(['name':'github.com/hashicorp/hcl/hcl/strconv', 'version':'973f376f0e7cf09c96e445b44712416c0cb22ec4', 'transitive':false])
-        build(['name':'github.com/hashicorp/hcl/hcl/token', 'version':'973f376f0e7cf09c96e445b44712416c0cb22ec4', 'transitive':false])
-        build(['name':'github.com/hashicorp/hcl/json/parser', 'version':'973f376f0e7cf09c96e445b44712416c0cb22ec4', 'transitive':false])
-        build(['name':'github.com/hashicorp/hcl/json/scanner', 'version':'973f376f0e7cf09c96e445b44712416c0cb22ec4', 'transitive':false])
-        build(['name':'github.com/hashicorp/hcl/json/token', 'version':'973f376f0e7cf09c96e445b44712416c0cb22ec4', 'transitive':false])
-        build(['name':'github.com/hokaccha/go-prettyjson', 'version':'f75235bd99dad4e98ff360db8372d5c0ef1d054a', 'transitive':false])
-        build(['name':'github.com/inconshreveable/mousetrap', 'version':'76626ae9c91c4f2a10f34cad8ce83ea42c93bb75', 'transitive':false])
-        build(['name':'github.com/magiconair/properties', 'version':'0723e352fa358f9322c938cc2dadda874e9151a9', 'transitive':false])
-        build(['name':'github.com/mattn/go-colorable', 'version':'d228849504861217f796da67fae4f6e347643f15', 'transitive':false])
-        build(['name':'github.com/mattn/go-isatty', 'version':'a5cdd64afdee435007ee3e9f6ed4684af949d568', 'transitive':false])
-        build(['name':'github.com/mitchellh/mapstructure', 'version':'f3009df150dadf309fdee4a54ed65c124afad715', 'transitive':false])
-        build(['name':'github.com/nicksnyder/go-i18n/i18n', 'version':'991e81cc94f6c54209edb3192cb98e3995ad71c1', 'transitive':false])
-        build(['name':'github.com/nicksnyder/go-i18n/i18n/bundle', 'version':'991e81cc94f6c54209edb3192cb98e3995ad71c1', 'transitive':false])
-        build(['name':'github.com/nicksnyder/go-i18n/i18n/language', 'version':'991e81cc94f6c54209edb3192cb98e3995ad71c1', 'transitive':false])
-        build(['name':'github.com/nicksnyder/go-i18n/i18n/translation', 'version':'991e81cc94f6c54209edb3192cb98e3995ad71c1', 'transitive':false])
-        build(['name':'github.com/apache/openwhisk-client-go/whisk', 'version':'ee5b8709787cd37201c42e38040e9709f6d1e9c8', 'transitive':false])
-        build(['name':'github.com/apache/openwhisk-client-go/wski18n', 'version':'ee5b8709787cd37201c42e38040e9709f6d1e9c8', 'transitive':false])
-        build(['name':'github.com/pelletier/go-buffruneio', 'version':'df1e16fde7fc330a0ca68167c23bf7ed6ac31d6d', 'transitive':false])
-        build(['name':'github.com/pelletier/go-toml', 'version':'45932ad32dfdd20826f5671da37a5f3ce9f26a8d', 'transitive':false])
-        build(['name':'github.com/spf13/afero', 'version':'06b7e5f50606ecd49148a01a6008942d9b669217', 'transitive':false])
-        build(['name':'github.com/spf13/afero/mem', 'version':'06b7e5f50606ecd49148a01a6008942d9b669217', 'transitive':false])
-        build(['name':'github.com/spf13/cast', 'version':'2580bc98dc0e62908119e4737030cc2fdfc45e4c', 'transitive':false])
-        build(['name':'github.com/spf13/cobra', 'version':'6e91dded25d73176bf7f60b40dd7aa1f0bf9be8d', 'transitive':false])
-        build(['name':'github.com/spf13/jwalterweatherman', 'version':'33c24e77fb80341fe7130ee7c594256ff08ccc46', 'transitive':false])
-        build(['name':'github.com/spf13/pflag', 'version':'5ccb023bc27df288a957c5e994cd44fd19619465', 'transitive':false])
-        build(['name':'github.com/spf13/viper', 'version':'651d9d916abc3c3d6a91a12549495caba5edffd2', 'transitive':false])
-        build(['name':'golang.org/x/sys/unix', 'version':'9a2e24c3733eddc63871eda99f253e2db29bd3b9', 'transitive':false])
-        build(['name':'golang.org/x/text/transform', 'version':'a8b38433e35b65ba247bb267317037dee1b70cea', 'transitive':false])
-        build(['name':'golang.org/x/text/unicode/norm', 'version':'a8b38433e35b65ba247bb267317037dee1b70cea', 'transitive':false])
-        build(['name':'gopkg.in/yaml.v2', 'version':'eb3733d160e74a9c7e442f435eb3bea458e1d19f', 'transitive':false])
-        build(['name':'github.com/palantir/stacktrace', 'version':'78658fd2d1772b755720ed8c44367d11ee5380d6', 'transitive':false])
-        build(['name':'github.com/cpuguy83/go-md2man/md2man', 'version':'1d903dcb749992f3741d744c0f8376b4bd7eb3e1', 'transitive':false])
-
-        test(['name':'github.com/stretchr/testify', 'version':'b91bfb9ebec76498946beb6af7c0230c7cc7ba6c', 'transitive':false])
-
-    }
-}
-*/
-
+// File exclusions for the Apache Rat scanning tool
 rat {
     excludes += [
         '.gradletasknamecache', 'gradle/wrapper/**', 'gradlew*', 'build/**', // Gradle

--- a/build.gradle
+++ b/build.gradle
@@ -37,7 +37,7 @@ golang {
     buildTags = (rootProject.findProperty('goTags')?:'').split(',')
 }
 
-// The `gogradle` plugin was designed to work with govendor and godeps
+// The `gogradle` plugin was designed to work with `govendor` and `godeps` tools
 // We must disable its tasks that attempt to "fetch" dpendendencies
 // into a "/vendor" directory and use them to build the project (which will fail)
 installDependencies.enabled = false


### PR DESCRIPTION
ideally, I would love to replace the `gogradle` plugin (no sig. updates since 2017) with something more aware of the post go 1.11 moduling system and supports cross platform/arch builds simply.  However, we need a means to prevent `gogradle` from using a "/vendor" directory and attempting to fetch its own packages/versions.