### PR TITLE
Documentation cleanup, post-gogradle build changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,8 +159,9 @@ After compiling, a suitable wskdeploy binary that works for your OS platform wil
 
     > **Note** Gradle v6 is not yet supported.
 
-1. For Windows type ```gradlew.bat distDocker```. For Linux/Unix/Mac, please type ```./gradlew distDocker```. These
-commands will start the wskdeploy cross compile for your specific OS platform inside a Docker container.
+1. For Windows type ```gradlew.bat distDocker```. For Linux/Unix/Mac, please type ```./gradlew distDocker```.
+
+    These commands will start the wskdeploy cross compile for your specific OS platform inside a Docker container.
 
 1. After build success, you should find a correct binary under current /bin dir of you openwhisk-deploy clone dir.
 

--- a/README.md
+++ b/README.md
@@ -154,29 +154,56 @@ After compiling, a suitable wskdeploy binary that works for your OS platform wil
 
 1. Verify your installed Gradle version is `5.5.1` (or higher)
 
-    - If you use Windows OS, type ```gradlew.bat -version ```.
-    - For Unix/Linux/Mac, please type ```./gradlew -version```.
+    - On Windows OS, type ```gradlew.bat -version ```.
+    - On Unix/Linux/Mac, please type ```./gradlew -version```.
 
     > **Note** Gradle v6 is not yet supported.
 
-1. For Windows type ```gradlew.bat distDocker```. For Linux/Unix/Mac, please type ```./gradlew distDocker```.
+1. Cross-compile binaries for all supported Operating Systems and Architectures:
 
-    These commands will start the wskdeploy cross compile for your specific OS platform inside a Docker container.
+    - On Windows, type ```gradlew.bat goBuild```
+    - On Linux/Unix/Mac, please type ```./gradlew goBuild```.
 
-1. After build success, you should find a correct binary under current /bin dir of you openwhisk-deploy clone dir.
+1. Upon a successful build, all binaries can be found within the `./build` directory of your project:
 
-If you would like to build the binaries available for all the operating systems and architectures, run the following command:
+    ```sh
+    $ ls build
+    darwin-amd64  linux-amd64   linux-arm64   linux-s390x   windows-amd64
+    linux-386     linux-arm     linux-ppc64le windows-386
+    ```
 
-```sh
-$ ./gradlew distDocker -PcrossCompileWSKDEPLOY=true
-```
+#### Compiling for a single OS/ARCH
 
-Then, you will find the binaries and their compressed packages generated under the folder ```bin/<os>/<arch>/``` for each supported Operating System and CPU Architecture pair.
+1. View gradle build tasks for supported Operating Systems and Architectures:
 
-### Building for Internationalization
+    ```sh
+    ./gradlew tasks
+    ```
+
+    you will see build tasks for supported OS/ARCH combinations:
+
+    ```sh
+    Gogradle tasks
+    --------------
+    buildDarwinAmd64 - Custom go task.
+    buildLinux386 - Custom go task.
+    buildLinuxAmd64 - Custom go task.
+    buildLinuxArm - Custom go task.
+    buildLinuxArm64 - Custom go task.
+    buildLinuxPpc64le - Custom go task.
+    buildLinuxS390x - Custom go task.
+    buildWindows386 - Custom go task.
+    buildWindowsAmd64 - Custom go task.
+    ```
+
+    > Note: The `buildWindows386` option is only supported on Golang versions less than 1.15.
+
+#### Building for Internationalization
 
 Please follow this process for building any changes to translatable strings:
 - [How to generate the file i18n_resources.go for internationalization](https://github.com/apache/openwhisk-wskdeploy/blob/master/wski18n/README.md)
+
+---
 
 ### Running as a Go program
 

--- a/build.gradle
+++ b/build.gradle
@@ -38,7 +38,7 @@ golang {
 }
 
 // The `gogradle` plugin was designed to work with `govendor` and `godeps` tools
-// We must disable its tasks that attempt to "fetch" dpendendencies
+// We must disable its tasks that attempt to "fetch" dependencies
 // into a "/vendor" directory and use them to build the project (which will fail)
 installDependencies.enabled = false
 resolveBuildDependencies.enabled = false

--- a/parsers/manifest_parser_test.go
+++ b/parsers/manifest_parser_test.go
@@ -1924,9 +1924,9 @@ func TestParseYAML_param(t *testing.T) {
 					assert.Equal(t, false, param.Value, "Get param value failed.")
 				case "inline0":
 					assert.Equal(t, 456.423, param.Value, "Get param value failed.")
-				case "inlin10":
+				case "inline10":
 					assert.Equal(t, nil, param.Value, "Get param value failed.")
-				case "inlin11":
+				case "inline11":
 					assert.Equal(t, true, param.Value, "Get param value failed.")
 				case "expand1":
 					assert.Equal(t, nil, param.Value, "Get param value failed.")

--- a/specification/html/spec_actions.md
+++ b/specification/html/spec_actions.md
@@ -20,6 +20,7 @@
 ## Actions
 
 #### Subsections
+
 - [Fields](#fields)
 - [Requirements](#requirements)
 - [Notes](#notes)
@@ -32,6 +33,7 @@
 The Action entity schema contains the necessary information to deploy an OpenWhisk function and define its deployment configurations, inputs and outputs.
 
 ### Fields
+
 | Key Name | Required | Value Type | Default | Description |
 |:---|:---|:---|:---|:---|
 | version | no | [version](spec_parameter_types.md#openwhisk-types) | N/A | The optional user-controlled version for the Action. |
@@ -78,6 +80,7 @@ The following annotations have special meanings for Actions:
 - When the `code` key-value is specified, the `runtime` **SHALL** be a required field.
 
 #### Annotation requirements
+
 - The annotation `require-whisk-auth` **SHALL** only be valid for web actions (i.e., if the `web` key or `web-export` annotation is set to `true`).
 - If the value of the `require-whisk-auth` annotation is an `integer` its value **MUST** be a positive integer less than or equal to the `MAX_INT` value of `9007199254740991`.
 - When the `web` or `web-export` key is present and set to `true` the web action's **MUST** also be marked `final`.  This happens automatically when the `web` or `web-export` keys are present and set to `true`.
@@ -175,11 +178,11 @@ See the file [runtimes.json](https://github.com/apache/openwhisk/blob/master/ans
 the main [apache/openwhisk](https://github.com/apache/openwhisk) repository for the latest supported runtimes nad versions.
 
 #### Notes
+
 - **WARNING**: _For OpenWhisk project builds, the Docker image used is tagged `nightly` in Docker Hub (e.g, for GitHub pull
 requests). Production uses of OpenWhisk code may use different images and tagged (released) image versions._
 - If no value for `runtime` is supplied, the value `language:default` will be assumed.
 - OpenWhisk runtimes may also include additional built-in packages (or libraries) that have been determined be useful for Actions surveyed and tested by the OpenWhisk platform.
-
 
 ### Recognized File extensions
 

--- a/specification/html/spec_apis.md
+++ b/specification/html/spec_apis.md
@@ -22,6 +22,7 @@
 The API entity schema is used to define an OpenWhisk API within a manifest.
 
 ### Fields
+
 <html>
 <table width="100%">
  <tr>

--- a/specification/html/spec_entity_naming_and_namespacing.md
+++ b/specification/html/spec_entity_naming_and_namespacing.md
@@ -26,7 +26,7 @@ packages, belongs in a *namespace.*
 
 The fully qualified name of any entity has the format:
 
-```
+```sh
 /<namespaceName>[/<packageName>]/<entityName>
 ```
 
@@ -34,7 +34,7 @@ The namespace is typically provided at bind-time by the user deploying the packa
 
 #### Requirements
 
--   The “/whisk.system“ namespace is reserved for entities that are distributed with the OpenWhisk system.
+- The “/whisk.system“ namespace is reserved for entities that are distributed with the OpenWhisk system.
 
 ### Entity Names
 
@@ -42,17 +42,19 @@ The names of all entities, including actions, triggers, rules, packages,
 and namespaces, are a sequence of characters that follow the following
 format:
 
--   The first character SHALL be an alphanumeric character, a digit, or an underscore.
--   The subsequent characters MAY be alphanumeric, digits, spaces, or any of the following:
-```
-_, @, ., -
-```
+- The first character SHALL be an alphanumeric character, a digit, or an underscore.
+- The subsequent characters MAY be alphanumeric, digits, spaces, or any of the following:
+
+    ```sh
+    _, @, ., -
+    ```
+
 - The last character SHALL NOT be a space.
 - The maximum name length of any entity name is 256 characters (i.e., ENTITY_NAME_MAX_LENGTH = 256).
 
 Valid entity names are described with the following regular expression (Java metacharacter syntax):
 
-```
+```sh
 "\A([\w]|[\w][\w@ .-]{0,${ENTITY_NAME_MAX_LENGTH - 2}}[\w@.-])\z"
 ```
 

--- a/specification/html/spec_intro.md
+++ b/specification/html/spec_intro.md
@@ -31,15 +31,15 @@ Development Kits (SDKs).
 The code for the Actions, along with any support services implementing *Feeds*, are packaged according to this specification to be compatible with the OpenWhisk catalog and its tooling. It also serves as a means for architects and developers to model OpenWhisk package Actions as part
 of full, event-driven services and applications providing the necessary information for artifact and data type validation along with package management operations.
 
-### Compatibility
+## Compatibility
 
 This specification is intended to be compatible with the following specifications:
 
--   *OpenWhisk API which is defined as an OpenAPI document: *
-    -   <https://github.com/apache/openwhisk/blob/master/core/controller/src/main/resources/apiv1swagger.json>
+- *OpenWhisk API which is defined as an OpenAPI document:*
+    - <https://github.com/apache/openwhisk/blob/master/core/controller/src/main/resources/apiv1swagger.json>
 
--   *OpenAPI Specification when defining REST APIs and parameters:*
-    -   <https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md>
+- *OpenAPI Specification when defining REST APIs and parameters:*
+    - <https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md>
 
 <!--
  Bottom Navigation

--- a/specification/html/spec_maps.md
+++ b/specification/html/spec_maps.md
@@ -29,6 +29,7 @@ entities.
 ```
 
 ##### Multi-line grammar
+
 ```yaml
 # Where ‘key_n’ is a type <string> and ‘value_n’ is type <any>.
 <key_1>: <value_1>

--- a/specification/html/spec_normative_refs.md
+++ b/specification/html/spec_normative_refs.md
@@ -17,26 +17,21 @@
 #
 -->
 
-
 <!--
 ********************************
   Normative Reference
 ********************************
 -->
 <h2>Normative References</h2>
-<p>&nbsp;</p>
+
 <table width="100%">
  <tr>
-  <th>
-  <p>Tag</p>
-  </th>
-  <th>
-  <p>Description</p>
-  </th>
+  <th>Tag</th>
+  <th>Description</th>
  </tr>
  <tr>
   <td>
-  <p><a>RFC2119</a></p>
+  <p>RFC2119</p>
   </td>
   <td>
   <p>S. Bradner, <i>Key words for use in RFCs to Indicate Requirement Levels</i>, <a href="http://www.ietf.org/rfc/rfc2119.txt">http://www.ietf.org/rfc/rfc2119.txt</a>, IETF RFC 2119, March 1997.</p>
@@ -44,7 +39,7 @@
  </tr>
  <tr>
   <td>
-  <p><a>YAML-1.2</a></p>
+  <p>YAML-1.2</p>
   </td>
   <td>
   <p>YAML, Version 1.2, 3rd Edition, Patched at 2009-10-01, Oren Ben-Kiki, Clark Evans, Ingy dšt Net <a href="http://www.yaml.org/spec/1.2/spec.html">http://www.yaml.org/spec/1.2/spec.html</a></p>
@@ -52,7 +47,7 @@
  </tr>
  <tr>
   <td>
-  <p><a>YAML-TS-1.1</a></p>
+  <p>YAML-TS-1.1</p>
   </td>
   <td>
   <p>Timestamp Language-Independent Type for YAML Version 1.1, Working Draft 2005-01-18, <a href="http://yaml.org/type/timestamp.html">http://yaml.org/type/timestamp.html</a></p>
@@ -60,7 +55,7 @@
  </tr>
  <tr>
   <td>
-  <p><a>Maven-Version</a></p>
+  <p>Maven-Version</p>
   </td>
   <td>
   <p>The version type is defined with the <a href="https://maven.apache.org/index.html">Apache Maven project's</a> policy draft:</p>
@@ -69,7 +64,7 @@
  </tr>
  <tr>
   <td>
-  <p><a>OpenAPI-2.0</a></p>
+  <p>OpenAPI-2.0</p>
   </td>
   <td>
   <p>The OpenAPI (f.k.a. 'Swagger') specification for defining REST APIs as JSON.</p>
@@ -78,7 +73,7 @@
  </tr>
  <tr>
   <td>
-  <p><a>Linux-SPDX</a></p>
+  <p>Linux-SPDX</p>
   </td>
   <td>
   <p>Linux Foundation, SPDX License list</p>
@@ -87,7 +82,7 @@
  </tr>
  <tr>
   <td>
-  <p><a>NPM-SPDX-Syntax</a></p>
+  <p>NPM-SPDX-Syntax</p>
   </td>
   <td>
   <p>Node Package Manager (NPM) SPDX License Expression Syntax</p>
@@ -103,19 +98,15 @@
 -->
 
 <h2>Non-normative References</h2>
-<p>&nbsp;</p>
+
 <table width="100%">
  <tr>
-  <th>
-  <p>Tag</p>
-  </th>
-  <th>
-  <p>Description</p>
-  </th>
+  <th>Tag</th>
+  <th>Description</th>
  </tr>
  <tr>
   <td>
-  <p><a>OpenWhisk-API</a></p>
+  <p>OpenWhisk-API</p>
   </td>
   <td>
   <p>OpenWhisk REST API which is defined as an OpenAPI document.</p>
@@ -124,7 +115,7 @@
  </tr>
  <tr>
   <td>
-  <p><a>GNU-units</a></p>
+  <p>GNU-units</p>
   </td>
   <td>
   <p>Size-type units are based upon a subset of those defined by GNU at <a href="http://www.gnu.org/software/parted/manual/html_node/unit.html">http://www.gnu.org/software/parted/manual/html_node/unit.html</a></p>
@@ -132,7 +123,7 @@
  </tr>
  <tr>
   <td>
-  <p><a>RFC 6838</a></p>
+  <p>RFC 6838</p>
   </td>
   <td>
   <p>Mime Type definitions in compliance with <a href="http://tools.ietf.org/html/rfc6838">RFC 6838</a>.</p>
@@ -140,7 +131,7 @@
  </tr>
  <tr>
   <td>
-  <p><a>RFC 7231</a></p>
+  <p>RFC 7231</p>
   </td>
   <td>
   <p>HTTP 1.1. status codes are described in compliance with <a href="http://tools.ietf.org/html/rfc7231#section-6">RFC 7231</a>.</p>
@@ -148,7 +139,7 @@
  </tr>
  <tr>
   <td>
-  <p><a>IANA-Status-Codes</a></p>
+  <p>IANA-Status-Codes</p>
   </td>
   <td>
   <p>HTTP Status codes as defined in the <a href="http://www.iana.org/assignments/http-status-codes/http-status-codes.xhtml">IANA Status Code Registry</a>.</p>
@@ -159,8 +150,8 @@
   <p>JSON Schema Specification</p>
   </td>
   <td>
-  <p>The built-in parameter type 'json' references this specification.</p>
-  <p>http://json-schema.org/</p>
+  <p>The built-in parameter type 'json' references this specification:
+  <a href="http://json-schema.org/">http://json-schema.org/</a></p>
   </td>
  </tr>
 </table>

--- a/specification/html/spec_package_processing.md
+++ b/specification/html/spec_package_processing.md
@@ -22,12 +22,12 @@
 This document defines two file artifacts that are used to deploy
 Packages to a target OpenWhisk platform; these include:
 
--   ***Package Manifest file***: Contains the Package definition along
+- ***Package Manifest file***: Contains the Package definition along
     with any included Action, Trigger or Rule definitions that comprise
     the package. This file includes the schema of input and output data
     to each entity for validation purposes.
 
--   ***Deployment file*** (optional): Contains the values and bindings used
+- ***Deployment file*** (optional): Contains the values and bindings used
     configure a Package to a target OpenWhisk platform provider’s
     environment and supply input parameter values for Packages, Actions
     and Triggers. This can include Namespace bindings, security and
@@ -35,9 +35,8 @@ Packages to a target OpenWhisk platform; these include:
 
 #### Notes
 
--   _Deployment files are optional_. Deployment can be fully accomplished
+- _Deployment files are optional_. Deployment can be fully accomplished
     with simply a Manifest File.
-
 
 ### Conceptual Package creation and publishing
 

--- a/specification/html/spec_parameter_types.md
+++ b/specification/html/spec_parameter_types.md
@@ -17,7 +17,7 @@
 #
 -->
 
-# Parameter Types
+## Parameter Types
 
 - [YAML Types](#yaml-types)
 - [OpenWhisk Types](#openwhisk-types)
@@ -25,7 +25,7 @@
 
 ---
 
-#### YAML Types
+### YAML Types
 
 Many of the types we use in this profile are *built-in* types from the [YAML 1.2 specification](http://www.yaml.org/spec/1.2/spec.html) (i.e., those identified by the “tag:yaml.org,2002” version tag).
 
@@ -40,7 +40,7 @@ The following table declares the valid YAML type URIs and aliases that SHALL be 
 | timestamp | tag:yaml.org,2002:timestamp | ISO 8601 compatible timestamp. See [YAML-TS-1.1](spec_normative_refs.md) |
 | null      | tag:yaml.org,2002:null | Different meaning than an empty string, map, list, etc. |
 
-#### Requirements
+### Requirements
 
 - The ‘string’ type SHALL be the default type when not specified on a parameter or property declaration.
 - All ‘boolean’ values SHALL be lowercased (i.e., ‘true’ or ‘false’).

--- a/specification/html/spec_parameters.md
+++ b/specification/html/spec_parameters.md
@@ -23,12 +23,14 @@
 - [Dollar Notation ($)](#dollar-notation--schema-for-values)
 
 ## Parameter schema
+
 The Parameter schema is used to define input and/or output data to be used by OpenWhisk entities for the purposes of validation.
 
 ### Fields
+
 | Key Name | Required | Value Type | Default | Description |
 |:---|:---|:---|:---|:---|
-| type       | no | _&lt;any&gt;_ | string | Optional valid type name or the parameter’s value for alidation purposes. By default, the type is string. |
+| [type](./spec_parameter_types.md) | no | _&lt;any&gt;_ | string | Optional valid type name or the parameter’s value for validation purposes. By default, the type is string. |
 | description | no | string256 | N/A | Optional description of the Parameter. |
 | value      | no | _&lt;any&gt;_ | N/A | The optional user supplied value for the parameter.</br> Note: this is not the default value, but an explicit declaration which allows simple usage of the Manifest file without a Deployment file. |
 | required   | no | boolean    | true | Optional indicator to declare the parameter as required (i.e., true) or optional (i.e., false). |
@@ -43,20 +45,50 @@ The 'schema' key's value MUST be compatible with the value provided on both the 
 
 ### Notes
 
-The 'type' key acknowledges some popular schema (e.g., JSON) to use when validating the value of the parameter. In the future additional (schema) types may be added for convenience.
+The `type` key acknowledges some popular schema (e.g., JSON) to use when validating the value of the parameter. In the future additional (schema) types may be added for convenience.
 
-### Grammar
+### Examples
 
-#### Single-line
+#### Single-line declaration *(type inferred)*
+
 ```yaml
+...
+  inputs:
+    inline1: '{ "key": true }'
+    inline2: Just a string
+    inline3: null
+    inline4: true
+    inline5: 42
+    inline6: -531
+    inline7: 432.432E-43
+    inline8: '[ true, null, "boo", { "key": 0 }]'
+    inline9: !!bool false
+    inline0: !!float 456.423
+    inline10:  # JSON null
+    inline11: True # JSON true
 ```
 
-Where <YAML type> is inferred to be a YAML type as shown in the YAML Types section above (e.g., string, integer, float, boolean, etc.).
+Where `<YAML type>` is inferred to be a YAML type as shown in the YAML Types section above (e.g., string, integer, float, boolean, etc.).
 
 If you wish the parser to validate against a different schema, then the multi-line grammar MUST be used where the value would be supplied on the keyname 'value' and the type (e.g., 'json') and/or schema (e.g., OpenAPI) can be supplied.
 
-#### Multi-line
+#### Multi-line declaration *(explicitly typed)*
+
 ```yaml
+...
+  inputs:
+    multiline1:
+      value: null
+      type: string
+      description: "null string"
+    multiline2:
+      value: "hello"
+      type: string
+      description: "greeting"
+    multiline3:
+      value: '{ "key": true }'
+      type: string
+      description: "map as string"
 ```
 
 ### Status values

--- a/specification/html/spec_parameters.md
+++ b/specification/html/spec_parameters.md
@@ -156,11 +156,13 @@ annotations: <map of <string>>
 In a Manifest or Deployment file, a parameter value may be set from the local execution environment by using the dollar ($) notation to denote names of local environment variables which supply the value to be inserted at execution time.
 
 ### Syntax
+
 ```yaml
 <parameter>: $<local environment variable name>
 ```
 
 ### Examples
+
 ```yaml
 ...
   inputs:
@@ -180,7 +182,6 @@ More examples of dollar notation, including use within JSON data, can be found h
 
 - Processors or tooling that encounter ($) Dollar notation for values should attempt to locate the corresponding named variables set into the local execution environment (e.g., where the tool was invoked) and assign its value to the named input parameter for the OpenWhisk entity.
 - This specification does not currently consider using this notation for other than simple data types (i.e., we support this mechanism for values such as `strings`, `integers`, `floats`, etc.) at this time.
-
 
 <!--
  Bottom Navigation

--- a/specification/html/spec_parameters.md
+++ b/specification/html/spec_parameters.md
@@ -41,7 +41,7 @@ The Parameter schema is used to define input and/or output data to be used by Op
 
 ### Requirements
 
-The 'schema' key's value MUST be compatible with the value provided on both the 'type'  and 'value' keys; otherwise, it is considered an error.
+The `schema` key's value MUST be compatible with the value provided on both the 'type'  and 'value' keys; otherwise, it is considered an error.
 
 ### Notes
 
@@ -66,6 +66,10 @@ The `type` key acknowledges some popular schema (e.g., JSON) to use when validat
     inline0: !!float 456.423
     inline10:  # JSON null
     inline11: True # JSON true
+    inline12: ["v1", "v2"]  # Array
+    inline13: # Array
+      - "value1"
+      - "value2"
 ```
 
 Where `<YAML type>` is inferred to be a YAML type as shown in the YAML Types section above (e.g., string, integer, float, boolean, etc.).
@@ -78,18 +82,30 @@ If you wish the parser to validate against a different schema, then the multi-li
 ...
   inputs:
     multiline1:
-      value: null
-      type: string
-      description: "null string"
-    multiline2:
       value: "hello"
       type: string
       description: "greeting"
-    multiline3:
+    multiline2:
       value: '{ "key": true }'
       type: string
       description: "map as string"
+    multiline3:
+      value: null
+      type: string
+      description: "null string"
+    multiline4:
+      value: 42
+      type: integer
+    multiline:
+      value: 456.423
+      type: float
 ```
+
+More examples of multiline, including advanced types like JSON, can be found here:
+
+- [docs/examples/manifest_hello_world_advanced_parms.yaml](docs/examples/manifest_hello_world_advanced_parms.yaml)
+- [tests/dat/manifest_validate_multiline_params.yaml](tests/dat/manifest_validate_multiline_params.yaml)
+- [tests/dat/manifest_validate_json_params.yaml](tests/dat/manifest_validate_json_params.yaml)
 
 ### Status values
 
@@ -133,6 +149,7 @@ annotations: <map of <string>>
 
 - Several, non-normative "annotations" keynames and allowed values (principally for User Interface (UI) design and tooling information) may be defined in this specification or optional usage.
 
+---
 
 ## Dollar Notation ($) schema for values
 
@@ -143,12 +160,17 @@ In a Manifest or Deployment file, a parameter value may be set from the local ex
 <parameter>: $<local environment variable name>
 ```
 
-### Example
+### Examples
 ```yaml
 ...
   inputs:
     userName: $DEFAULT_USERNAME
 ```
+
+More examples of dollar notation, including use within JSON data, can be found here:
+
+- [docs/examples/manifest_hello_world_env_var_parms.yaml](docs/examples/manifest_hello_world_env_var_parms.yaml)
+- [tests/dat/manifest_validate_json_params.yaml](tests/dat/manifest_validate_json_params.yaml)
 
 ### Requirements
 

--- a/specification/html/spec_rule.md
+++ b/specification/html/spec_rule.md
@@ -22,6 +22,7 @@
 The Rule entity schema contains the information necessary to associates one trigger with one action, with every firing of the trigger causing the corresponding action to be invoked with the trigger event as input. For more information, see the document "[Creating Triggers and Rules](https://github.com/apache/openwhisk/blob/master/docs/triggers_rules.md)".
 
 #### Subsections
+
 - [Fields](#fields)
 - [Requirements](#requirements)
 - [Notes](#notes)
@@ -29,6 +30,7 @@ The Rule entity schema contains the information necessary to associates one trig
 - [Example](#example)
 
 ### Fields
+
 <html>
 <table>
   <tr>

--- a/specification/html/spec_schema.md
+++ b/specification/html/spec_schema.md
@@ -17,7 +17,7 @@
 #
 -->
 
-# Schema
+## Schema
 
 This section defines all the essential schema used to describe OpenWhisk packages and programming model entities within a manifest.
 

--- a/specification/html/spec_sequences.md
+++ b/specification/html/spec_sequences.md
@@ -22,6 +22,7 @@
 Actions can be composed into sequences to, in effect, form a new Action. The Sequence entity allows for a simple, convenient way to describe them in the Package Manifest.
 
 ### Fields
+
 <html>
 <table>
   <tr>
@@ -77,6 +78,7 @@ sequences:
 ```
 
 ### Example
+
 ```yaml
 sequences:
   newbot:

--- a/specification/html/spec_shared_entity_schema.md
+++ b/specification/html/spec_shared_entity_schema.md
@@ -90,6 +90,7 @@ The Entity Schema contains fields that are common (shared) to all OpenWhisk enti
 </html>
 
 ### Grammar
+
 ```yaml
 description: <string256>
 displayName: <string16>
@@ -97,7 +98,8 @@ annotations: <map of <string>>
 ```
 
 ### Requirements
-- Non-required fields MAY be stored as ÒannotationsÓ within the OpenWhisk framework after they have been used for processing.
+
+- Non-required fields MAY be stored as `annotations` within the OpenWhisk framework after they have been used for processing.
 - Description string values SHALL be limited to 256 characters.
 - DisplayName string values SHALL be limited to 16 characters.
 - Annotations MAY be ignored by target consumers of the Manifest file as they are considered data non-essential to the deployment of management of OpenWhisk entities themselves.
@@ -105,6 +107,7 @@ annotations: <map of <string>>
 - For any OpenWhisk Entity, the maximum size of all Annotations SHALL be 256 characters.
 
 ### Notes
+
 - Several, non-normative Annotation keynames and allowed values for (principally for User Interface (UI) design) may be defined below for optional usage.
 
 <!--

--- a/specification/html/spec_trigger.md
+++ b/specification/html/spec_trigger.md
@@ -22,6 +22,7 @@
 The Trigger entity schema contains the necessary information to describe the stream of events that it represents. For more information, see the document "[Creating Triggers and Rules](https://github.com/apache/openwhisk/blob/master/docs/triggers_rules.md)".
 
 #### Subsections
+
 - [Fields](#fields)
 - [Requirements](#requirements)
 - [Notes](#notes)
@@ -29,6 +30,7 @@ The Trigger entity schema contains the necessary information to describe the str
 - [Example](#example)
 
 ### Fields
+
 <html>
 <table>
   <tr>
@@ -128,6 +130,7 @@ declared above.
   - ```$ wsk trigger list -v
 
 ### Grammar
+
 ```yaml
 <triggerName>:
   <Entity schema>
@@ -138,6 +141,7 @@ declared above.
 ```
 
 ### Example
+
 ```yaml
 triggers:
   everyhour:

--- a/tests/dat/deployment_validate_package_inputs_1.yaml
+++ b/tests/dat/deployment_validate_package_inputs_1.yaml
@@ -22,5 +22,3 @@ packages:
                 inputs:
                     name: Alice
                     place: Wonderland
-
-

--- a/tests/dat/manifest_validate_params.yaml
+++ b/tests/dat/manifest_validate_params.yaml
@@ -30,8 +30,8 @@ packages:
           inline8: '[ true, null, "boo", { "key": 0 }]'
           inline9: !!bool false
           inline0: !!float 456.423
-          inlin10:  # JSON null
-          inlin11: True # JSON true
+          inline10:  # JSON null
+          inline11: True # JSON true
 
           expand1:
             value: null


### PR DESCRIPTION
This is some docs. cleanup of typos and other spec. changes/mixups that were found while fixing gogradle.  

Also, sought to incorporate proposed change from PR https://github.com/apache/openwhisk-wskdeploy/pull/1094 which for some reason did not build at the time it was submitted