### PR TITLE
Adding Aarch64 support, for Travis

### DIFF
--- a/tools/travis/build_tag_releases.sh
+++ b/tools/travis/build_tag_releases.sh
@@ -17,7 +17,7 @@
 #
 
 declare -a os_list=("linux" "darwin" "windows")
-declare -a arc_list=("amd64" "386")
+declare -a arc_list=("amd64" "386" "arm64")
 build_file_name=${1:-"wskdeploy"}
 build_version=${2:-"$TRAVIS_TAG"}
 gitCommit=$(git rev-parse HEAD)


### PR DESCRIPTION
For supporting multi-arch cross-compilation.
But that is not solving my issues, for on-premise compilation (where host arch=guest arch, i.e. arm64)