### PR TITLE
JSON type can be bound to a package

### DIFF
--- a/parsers/manifest_parser.go
+++ b/parsers/manifest_parser.go
@@ -321,13 +321,13 @@ func (dm *YAMLParser) composePackageInputs(projectInputs map[string]Parameter, r
 		}
 		// if value is set to default value for its type,
 		// check for input key being an env. variable itself
-		if value == getTypeDefaultValue(i.Type) {
+		if safeCompare(value, getTypeDefaultValue(i.Type)) {
 			value = wskenv.InterpolateStringWithEnvVar("${" + name + "}")
 		}
 
 		// if at this point, still value is set to default value of its type
 		// check if input key is defined under Project Inputs
-		if value == getTypeDefaultValue(i.Type) {
+		if safeCompare(value, getTypeDefaultValue(i.Type)) {
 			if i.Type == STRING && i.Value != nil {
 				n := wskenv.GetEnvVarName(i.Value.(string))
 				if v, ok := projectInputs[n]; ok {
@@ -1503,4 +1503,10 @@ func isGatewayBasePathValid(basePath string) bool {
 		return false
 	}
 	return true
+}
+
+func safeCompare(a interface{}, b interface{}) bool {
+	aa, _ := json.Marshal(a)
+	bb, _ := json.Marshal(b)
+	return (string(aa) == string(bb))
 }


### PR DESCRIPTION
# issue
https://github.com/apache/openwhisk-wskdeploy/issues/1149

# Test
```sh
$ cat manifest.yaml    
project:
  packages:
    package1:
      inputs:
        param1:
          key1: value1
          key2: value2
      actions:
        action1:
          function: ./action1.js
          runtime: nodejs
$ go build -o ./wskdeploy
$ ./wskdeploy --preview
Packages:
Name: package1
    bindings: 
        - param1 : {
  "key1": "value1",
  "key2": "value2"
}
    annotation: 

  * action: action1
    bindings: 
    annotation: 


Triggers:

Rules

```