### PR TITLE
Fix runtimes kind go version update

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 # Whisk Deploy `wskdeploy`
 
 [![License](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](http://www.apache.org/licenses/LICENSE-2.0)
-[![Build Status](https://travis-ci.com/apache/openwhisk-wskdeploy.svg?branch=master)](https://travis-ci.com/apache/openwhisk-wskdeploy)
+[![Build Status](https://travis-ci.com/apache/openwhisk-wskdeploy.svg?branch=master)](https://travis-ci.com/github/apache/openwhisk-wskdeploy)
 
 `wskdeploy` is a utility to help you describe and deploy any part of the OpenWhisk programming model using a YAML manifest file. Use it to deploy all of your OpenWhisk project's [Packages](https://github.com/apache/openwhisk/blob/master/docs/packages.md), [Actions](https://github.com/apache/openwhisk/blob/master/docs/actions.md), [Triggers, and Rules](https://github.com/apache/openwhisk/blob/master/docs/triggers_rules.md), together, using a single command!
 

--- a/runtimes/runtimes.go
+++ b/runtimes/runtimes.go
@@ -461,7 +461,7 @@ var RUNTIME_DETAILS = []byte(`{
         ],
         "go": [
             {
-                "kind": "go:1.11",
+                "kind": "go:1.15",
                 "default": true,
                 "deprecated": false,
                 "attached": {


### PR DESCRIPTION
# issue

https://github.com/apache/openwhisk-wskdeploy/issues/1110

# overview

- The runtime type was updated because the integration test failed due to the omission of updating the go version of runtimes.
- fix travis URL
