### PR TITLE
docs: remove misleading web-export key

### DIFF
--- a/docs/export.md
+++ b/docs/export.md
@@ -225,13 +225,13 @@ packages:
         namespace: your_namespace/lib1_package
         credential: ""
         exposedUrl: ""
-        web-export: ""
         main: ""
         limits: null
         inputs: {}
         outputs: {}
         annotations:
           exec: nodejs:default
+          web-export: ""
     triggers: {}
     feeds: {}
     rules: {}


### PR DESCRIPTION
Top-level web-export was deprecated as part of https://github.com/apache/openwhisk-wskdeploy/pull/1092